### PR TITLE
remove grecord in potfiles.in

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -13,10 +13,6 @@ mate-volume-control/src/gvc-mixer-control.c
 mate-volume-control/src/gvc-mixer-dialog.c
 mate-volume-control/src/gvc-speaker-test.c
 mate-volume-control/src/gvc-stream-status-icon.c
-grecord/mate-sound-recorder.desktop.in.in
-grecord/mate-sound-recorder.schemas.in.in
-grecord/src/mate-recorder.c
-grecord/src/gsr-window.c
 gst-mixer/mate-volume-control.desktop.in.in
 gst-mixer/mate-volume-control.schemas.in
 gst-mixer/src/element.c

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,7 +1,5 @@
 mate-volume-control/data/mate-volume-control.desktop.in
 mate-volume-control/data/sounds/mate-sounds-default.xml.in
-grecord/mate-sound-recorder.desktop.in
-grecord/mate-sound-recorder.schemas.in
 gst-mixer/mate-volume-control.desktop.in
 gstreamer-properties/gstreamer-properties.desktop.in
 profiles/mate-audio-profiles.schemas.in


### PR DESCRIPTION
for building rpms i used those lines

strip unneeded translations from .mo files
ideally intltool (ha!) would do that for us
http://bugzilla.gnome.org/show_bug.cgi?id=474987
cd po
grep -v ".[.]desktop[.]in[.]in$|.[.]server[.]in[.]in$" POTFILES.in > POTFILES.keep
mv POTFILES.keep POTFILES.in
intltool-update --pot
for p in *.po; do
msgmerge $p %{gettext_package}.pot > $p.out
msgfmt -o basename $p .po.gmo $p.out
done

i get this error

make[1]: Leaving directory `/home/rave/rpmbuild/BUILD/mate-media-1.3.0'
cd po
grep -v '.[.]desktop[.]in[.]in$|.[.]server[.]in[.]in$' POTFILES.in
mv POTFILES.keep POTFILES.in
intltool-update --pot
can't open ./../grecord/mate-sound-recorder.schemas.in.in: No such file or directory at /usr/bin/intltool-extract line 211.
xgettext: error while opening "../grecord/mate-sound-recorder.schemas.in.in.h" for reading: No such file or directory
ERROR: xgettext failed to generate PO template file. Please consult
error message above if there is any.

the pull requeset fix this
