### PR TITLE
fix compilation errors for gstreamer support

### DIFF
--- a/sound-theme/Makefile.am
+++ b/sound-theme/Makefile.am
@@ -20,7 +20,7 @@ libsoundtheme_la_SOURCES = \
 	$(NULL)
 
 libsoundtheme_la_LIBADD = $(SOUND_THEME_LIBS)
-libsoundtheme_la_LDFLAGS = -no-undefined
+libsoundtheme_la_LDFLAGS = -lm
 
 BUILT_SOURCES =				\
 	$(NULL)


### PR DESCRIPTION
if gstreamer is enabled you will get the following errors:

/usr/bin/ld: volume.o: undefined reference to symbol 'rint@@GLIBC_2.2.5'
/usr/bin/ld: note: 'rint@@GLIBC_2.2.5' is defined in DSO /lib64/libm.so.6 so try adding it to the linker command line
/lib64/libm.so.6: could not read symbols: Invalid operation
collect2: error: ld returned 1 exit status
make[3]: **\* [mate-volume-control] Error 1
