### PR TITLE
Add missing Man pages for binaries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 NULL =
 
-SUBDIRS = po
+SUBDIRS = po man
 
 if HAVE_SOUND_THEME
 SUBDIRS += sound-theme
@@ -26,6 +26,7 @@ DISTCHECK_CONFIGURE_FLAGS = \
 
 DIST_SUBDIRS = \
 	po 			\
+	man			\
 	mate-volume-control	\
 	gst-mixer		\
 	gst-mixer-applet	\

--- a/configure.ac
+++ b/configure.ac
@@ -330,6 +330,7 @@ AC_SUBST(LDFLAGS)
 
 AC_CONFIG_FILES([
 Makefile
+man/Makefile
 po/Makefile.in
 sound-theme/Makefile
 sound-theme/sounds/Makefile

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,0 +1,7 @@
+man_MANS = mate-volume-control.1
+
+if HAVE_PULSEAUDIO
+man_MANS += mate-volume-control-applet.1
+endif
+
+EXTRA_DIST = mate-volume-control.1 mate-volume-control-applet.1

--- a/man/mate-volume-control-applet.1
+++ b/man/mate-volume-control-applet.1
@@ -1,0 +1,40 @@
+.\" Man Page for mate-volume-control-applet
+.TH MATE-VOLUME-CONTROL-APPLET 1 "20 February 2014" "MATE Desktop Environment"
+.\" Please adjust this date when revising the manpage.
+.\"
+.SH "NAME"
+\fBmate-volume-control-applet\fR \- The MATE Volume Applet
+.SH "SYNOPSIS"
+.B mate-volume-control [OPTIONS]
+.SH "DESCRIPTION"
+The MATE Volume Control Applet is used with Pulseaudio for adjusting audio levels from the notification area.
+.SH "OPTIONS"
+.TP
+\fB\-\-version\fR
+Output version information and exit.
+.TP
+\fB\-\-debug\fR
+Enable debugging code
+.TP
+\fB\-\-display=DISPLAY\fR
+X display to use.
+.TP
+\fB\-?, \-h, \-\-help\fR
+Print standard command line options.
+.TP
+\fB\-\-help\-all\fR
+Print all command line options.
+.P
+.SS \fRThis program also accepts the standard MATE/GTK+ options.
+.TP
+\fB\-\-help\-gtk\fR
+Print GTK+ options.
+.SH "BUGS"
+.SS Should you encounter any bugs, they may be reported at: 
+http://github.com/mate-desktop/mate-media/issues
+.SH "AUTHORS"
+.SS This Manual Page has been written for the MATE Desktop Environment by:
+Adam Erdman <hekel@archlinux.info> (2014)
+.SH "SEE ALSO"
+.SS Further information may also be available at: http://wiki.mate-desktop.org/docs
+.BR mate-volume-control (1)

--- a/man/mate-volume-control.1
+++ b/man/mate-volume-control.1
@@ -1,0 +1,38 @@
+.\" Man Page for mate-volume-control
+.TH MATE-VOLUME-CONTROL 1 "20 February 2014" "MATE Desktop Environment"
+.\" Please adjust this date when revising the manpage.
+.\"
+.SH "NAME"
+\fBmate-volume-control\fR \- The MATE Volume Controller
+.SH "SYNOPSIS"
+.B mate-volume-control [OPTIONS]
+.SH "DESCRIPTION"
+The MATE Volume Control application is an audio mixer that enables you to mix audio and adjust volume levels of various audio mixer devices on your system.
+.SH "OPTIONS"
+.TP
+\fB\-p, \-\-page=playback|recording|switches|options\fR
+Launch \fBmate\-volume\-control\fR on the specified page/tab.
+.TP
+\fB\-?, \-h, \-\-help\fR
+Print standard command line options.
+.TP
+\fB\-\-help\-all\fR
+Print all command line options.
+.TP
+\fB\-\-help\-gst\fR
+Print GStreamer Options
+.P
+.SS \fRThis program also accepts the standard MATE/GTK+ options.
+.TP
+\fB\-\-help\-gtk\fR
+Print GTK+ options.
+.SH "BUGS"
+.SS Should you encounter any bugs, they may be reported at: 
+http://github.com/mate-desktop/mate-media/issues
+.SH "AUTHORS"
+.SS This Manual Page has been written for the MATE Desktop Environment by:
+Adam Erdman <hekel@archlinux.info> (2014)
+.SH "SEE ALSO"
+.SS
+MATE Volume Control documentation can be found by clicking the "Help" button, or by pressing the F1 key. 
+Further information may also be available at: http://wiki.mate-desktop.org/docs


### PR DESCRIPTION
Addressing: https://github.com/mate-desktop/mate-media/issues/25

Create Makefile for man pages
Create mate-volume-control.1
Create mate-volume-control-applet.1
add dir man to mate-media Makefile.am
add man/Makefile to mate-media configure.ac
