### PR TITLE
Fix missing icons on GTK3 with custom icon theme

### DIFF
--- a/data/icons/16x16/status/Makefile.am
+++ b/data/icons/16x16/status/Makefile.am
@@ -1,6 +1,6 @@
 NULL =
 
-themedir = $(pkgdatadir)/icons/mate
+themedir = $(pkgdatadir)/icons/hicolor
 size = 16x16
 context = status
 

--- a/data/icons/22x22/status/Makefile.am
+++ b/data/icons/22x22/status/Makefile.am
@@ -1,6 +1,6 @@
 NULL =
 
-themedir = $(pkgdatadir)/icons/mate
+themedir = $(pkgdatadir)/icons/hicolor
 size = 22x22
 context = status
 

--- a/data/icons/24x24/status/Makefile.am
+++ b/data/icons/24x24/status/Makefile.am
@@ -1,6 +1,6 @@
 NULL =
 
-themedir = $(pkgdatadir)/icons/mate
+themedir = $(pkgdatadir)/icons/hicolor
 size = 24x24
 context = status
 

--- a/data/icons/32x32/status/Makefile.am
+++ b/data/icons/32x32/status/Makefile.am
@@ -1,6 +1,6 @@
 NULL =
 
-themedir = $(pkgdatadir)/icons/mate
+themedir = $(pkgdatadir)/icons/hicolor
 size = 32x32
 context = status
 

--- a/data/icons/scalable/devices/Makefile.am
+++ b/data/icons/scalable/devices/Makefile.am
@@ -1,6 +1,6 @@
 NULL =
 
-themedir = $(pkgdatadir)/icons/mate
+themedir = $(pkgdatadir)/icons/hicolor
 size = 48x48
 context = devices
 

--- a/data/icons/scalable/status/Makefile.am
+++ b/data/icons/scalable/status/Makefile.am
@@ -1,6 +1,6 @@
 NULL =
 
-themedir = $(pkgdatadir)/icons/mate
+themedir = $(pkgdatadir)/icons/hicolor
 size = scalable
 context = status
 


### PR DESCRIPTION
Test case:
1. Install the GTK3 version of mate-media.
2. Set icon theme to Adwaita.
3. Launch mate-volume-control.
4. See the missing icons on input volume slider.