### PR TITLE
GTK3: Support custom panel themes and transparency

### DIFF
--- a/mate-volume-control/gvc-stream-status-icon.c
+++ b/mate-volume-control/gvc-stream-status-icon.c
@@ -250,8 +250,21 @@ on_status_icon_popup_menu (GtkStatusIcon       *status_icon,
         GtkWidget *item;
 
         menu = gtk_menu_new ();
-        item = gtk_check_menu_item_new_with_mnemonic (_("_Mute"));
 
+        /*Set up theme and transparency support*/
+#if GTK_CHECK_VERSION (3, 0, 0) 
+        GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+        GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+        GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+        gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+/* Set menu and it's toplevel window to follow panel theme */
+        GtkStyleContext *context;
+        context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+        gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+        gtk_style_context_add_class(context,"mate-panel-menu-bar");
+#endif
+        item = gtk_check_menu_item_new_with_mnemonic (_("_Mute"));
         gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (item),
                                         mate_mixer_stream_control_get_mute (icon->priv->control));
         g_signal_connect (G_OBJECT (item),
@@ -769,6 +782,22 @@ gvc_stream_status_icon_init (GvcStreamStatusIcon *icon)
 
         gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar),
                                          GTK_ORIENTATION_VERTICAL);
+                                         
+       	/* Set volume control frame, slider and toplevel window to follow panel theme */   	
+#if GTK_CHECK_VERSION (3, 0, 0)  
+        GtkWidget *toplevel = gtk_widget_get_toplevel (icon->priv->dock);
+        GtkStyleContext *context;
+        context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+        gtk_style_context_remove_class (context,GTK_STYLE_CLASS_BACKGROUND);
+        gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+        gtk_style_context_add_class(context,"mate-panel-menu-bar");
+
+        /* Make transparency possible in gtk3 theme */   
+
+        GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+        GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+        gtk_widget_set_visual(GTK_WIDGET(toplevel), visual);
+#endif
 
 #if GTK_CHECK_VERSION (3, 0, 0)
         box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);


### PR DESCRIPTION
GTK3: Support custom panel themes and transparency.
This adds support for custom panel themes using the .mate-panel-menu-bar selector to control child widgets. The menus are controllled by .mate-panel-menu-bar .menu and most of the slider theme is that of the frame it is drawn in. The .mate-panel-menu-bar .frame selector will theme this frame, there is also an inner frame in the layout which will follow .mate-panel-menu-bar .frame .frame and otherwise display a second time anything specified in .mate-panel-menu-bar .frame . In most cases that can simply be set transparent.

Themes can use alpha values for both menus and slider backgrounds.

Entire repo remade as new fork from mate-desktop/master on Oct 12, coding style cleaned as asked with spaces instead of tabs (assuming the cut and paste preserved this) and the word "hack" removed from the comments identifying the changes