### PR TITLE
Gtk3.19 bugfix for volume slider position

### DIFF
--- a/mate-volume-control/gvc-stream-status-icon.c
+++ b/mate-volume-control/gvc-stream-status-icon.c
@@ -793,6 +793,7 @@ gvc_stream_status_icon_init (GvcStreamStatusIcon *icon)
         GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
         GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
         gtk_widget_set_visual(GTK_WIDGET(toplevel), visual);
+        gtk_widget_realize (icon->priv->dock); /*stop slider from first showing at top left in gtk3.20 */
 #endif
 
 #if GTK_CHECK_VERSION (3, 0, 0)


### PR DESCRIPTION
Another gtk_widget_realize () issue with gtk3.19: volume slider popped up first time at top left and afterwards was fine. This makes it come up over (or under) the volume control icon every time. Tested with current gtk3.19.5 and also with gtk3.14, no new issues in either.