### PR TITLE
applet: restore icon for "Sound Preferences" menu item

### DIFF
--- a/mate-volume-control/gvc-stream-status-icon.c
+++ b/mate-volume-control/gvc-stream-status-icon.c
@@ -265,6 +265,7 @@ on_status_icon_popup_menu (GtkStatusIcon       *status_icon,
 {
         GtkWidget *menu;
         GtkWidget *item;
+        GtkWidget *image;
 
         menu = gtk_menu_new ();
 
@@ -290,8 +291,10 @@ on_status_icon_popup_menu (GtkStatusIcon       *status_icon,
 
         gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
 
-        /* FIXME: we lost an icon with migrating from gtk_image_menu_item_new_with_mnemonic */
-        item = gtk_menu_item_new_with_mnemonic (_("_Sound Preferences"));
+        item = gtk_image_menu_item_new_with_mnemonic (_("_Sound Preferences"));
+        image = gtk_image_new_from_icon_name ("multimedia-volume-control",
+                                              GTK_ICON_SIZE_MENU);
+        gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (item), image);
 
         g_signal_connect (G_OBJECT (item),
                           "activate",


### PR DESCRIPTION
this adds some deprecated code but brings back the icon

it was lost for GTK+3 build here:
https://github.com/mate-desktop/mate-media/commit/0c558fac14266f8c18cfb8bc1d4669ed35868c2f#diff-411bda4b8f441c44b560abc7245dd33cR264