### PR TITLE
gvc-mixer-dialog.c: avoid deprecated 'gtk_widget_override_font'

### DIFF
--- a/mate-volume-control/gvc-mixer-dialog.c
+++ b/mate-volume-control/gvc-mixer-dialog.c
@@ -1307,7 +1307,12 @@ make_label_bold (GtkLabel *label)
          * from the current state of the widget, which comes from the
          * theme or user prefs, since the font desc only has the
          * weight flag turned on. */
-        gtk_widget_override_font (GTK_WIDGET (label), font_desc);
+        PangoAttrList *attrs = pango_attr_list_new ();
+        PangoAttribute *font_desc_attr = pango_attr_font_desc_new (font_desc);
+        pango_attr_list_insert (attrs, font_desc_attr);
+        gtk_label_set_attributes (label, attrs);
+        pango_attr_list_unref (attrs);
+
         pango_font_description_free (font_desc);
 }
 


### PR DESCRIPTION
The expected: the same look like before

This PR affects these items (in red):

![volume3](https://user-images.githubusercontent.com/7734191/42419341-132a6d1c-82b3-11e8-895f-dacf011f65da.png)
![volume2](https://user-images.githubusercontent.com/7734191/42419342-136a0f8a-82b3-11e8-9aa1-61496f8f87ad.png)
![volume1](https://user-images.githubusercontent.com/7734191/42419343-1398dbd0-82b3-11e8-9be5-8c787831c1eb.png)