### PR TITLE
Ignore PulseAudio "monitor" inputs when displaying mic icon

### DIFF
--- a/mate-volume-control/gvc-applet.c
+++ b/mate-volume-control/gvc-applet.c
@@ -79,6 +79,14 @@ update_icon_input (GvcApplet *applet)
 
                 control = mate_mixer_stream_get_default_control (applet->priv->input);
 
+                const gchar *stream_name =
+                        mate_mixer_stream_get_name (applet->priv->input);
+                g_debug ("Got stream name %s", stream_name);
+                if (g_str_has_suffix (stream_name, ".monitor")) {
+                        inputs = NULL;
+                        g_debug ("Stream is a monitor, ignoring");
+                }
+
                 while (inputs != NULL) {
                         MateMixerStreamControl    *input =
                                 MATE_MIXER_STREAM_CONTROL (inputs->data);


### PR DESCRIPTION
Teradici PCoIP on Linux presently has audio output but no audio input.
PulseAudio creates a "monitor" input device for each output device. These
combine so that a microphone icon is displayed in the tray even though no
actual input device is present. It's misleading, so we created this patch to
avoid it.