### PR TITLE
[WIP] mate-volume-control-applet: Use symbolic icons when available.

### DIFF
--- a/mate-volume-control/gvc-applet.c
+++ b/mate-volume-control/gvc-applet.c
@@ -42,11 +42,27 @@ static const gchar *icon_names_output[] = {
         NULL
 };
 
+static const gchar *icon_names_symbolic_output[] = {
+        "audio-status-volume-muted-symbolic",
+        "audio-status-volume-low-symbolic",
+        "audio-status-volume-medium-symbolic",
+        "audio-status-volume-high-symbolic",
+        NULL
+};
+
 static const gchar *icon_names_input[] = {
         "audio-input-microphone-muted",
         "audio-input-microphone-low",
         "audio-input-microphone-medium",
         "audio-input-microphone-high",
+        NULL
+};
+
+static const gchar *icon_names_symbolic_input[] = {
+        "audio-status-microphone-muted-symbolic",
+        "audio-status-microphone-low-symbolic",
+        "audio-status-microphone-medium-symbolic",
+        "audio-status-microphone-high-symbolic",
         NULL
 };
 
@@ -324,8 +340,16 @@ gvc_applet_init (GvcApplet *applet)
 {
         applet->priv = GVC_APPLET_GET_PRIVATE (applet);
 
-        applet->priv->icon_input  = gvc_stream_status_icon_new (NULL, icon_names_input);
-        applet->priv->icon_output = gvc_stream_status_icon_new (NULL, icon_names_output);
+        if (gtk_icon_theme_has_icon (gtk_icon_theme_get_default (), "audio-status-volume-muted-symbolic")) {
+            // The theme provides symbolic icons, use them.
+            applet->priv->icon_input  = gvc_stream_status_icon_new (NULL, icon_names_symbolic_input);
+            applet->priv->icon_output = gvc_stream_status_icon_new (NULL, icon_names_symbolic_output);
+        }
+        else {
+            // No symbolic icons provided by the theme, fallback to fullcolor icons.
+            applet->priv->icon_input  = gvc_stream_status_icon_new (NULL, icon_names_input);
+            applet->priv->icon_output = gvc_stream_status_icon_new (NULL, icon_names_output);
+        }
 
         gvc_stream_status_icon_set_display_name (applet->priv->icon_input,  _("Input"));
         gvc_stream_status_icon_set_display_name (applet->priv->icon_output, _("Output"));

--- a/mate-volume-control/gvc-applet.c
+++ b/mate-volume-control/gvc-applet.c
@@ -288,6 +288,21 @@ on_context_default_output_stream_notify (MateMixerContext *control,
         update_icon_output (applet);
 }
 
+static void
+on_icon_theme_change (GtkSettings         *settings,
+                      GParamSpec          *pspec,
+                      GvcApplet           *applet)
+{
+        if (gtk_icon_theme_has_icon (gtk_icon_theme_get_default (), "audio-status-volume-muted-symbolic")) {
+            gvc_stream_status_icon_set_icon_names (applet->priv->icon_input, icon_names_symbolic_input);
+            gvc_stream_status_icon_set_icon_names (applet->priv->icon_output, icon_names_symbolic_output);
+        }
+        else {
+            gvc_stream_status_icon_set_icon_names (applet->priv->icon_input, icon_names_input);
+            gvc_stream_status_icon_set_icon_names (applet->priv->icon_output, icon_names_output);
+        }
+}
+
 void
 gvc_applet_start (GvcApplet *applet)
 {
@@ -317,6 +332,10 @@ gvc_applet_dispose (GObject *object)
                                                       applet);
                 g_clear_object (&applet->priv->input);
         }
+
+        g_signal_handlers_disconnect_by_func (gtk_settings_get_default (),
+                                              on_icon_theme_change,
+                                              applet);
 
         g_clear_object (&applet->priv->context);
         g_clear_object (&applet->priv->icon_input);
@@ -379,6 +398,10 @@ gvc_applet_init (GvcApplet *applet)
         g_signal_connect (G_OBJECT (applet->priv->context),
                           "notify::default-output-stream",
                           G_CALLBACK (on_context_default_output_stream_notify),
+                          applet);
+        g_signal_connect (gtk_settings_get_default (),
+                          "notify::gtk-icon-theme-name",
+                          G_CALLBACK (on_icon_theme_change),
                           applet);
 }
 


### PR DESCRIPTION
Use the following icon names when available:

    "audio-status-volume-muted-symbolic",
    "audio-status-volume-low-symbolic",
    "audio-status-volume-medium-symbolic",
    "audio-status-volume-high-symbolic",
    "audio-status-microphone-muted-symbolic",
    "audio-status-microphone-low-symbolic",
    "audio-status-microphone-medium-symbolic",
    "audio-status-microphone-high-symbolic".

If these icons are not present in the icon theme, fallback to
fullcolor icons with legacy names (the same icons that were used
before):

    "audio-volume-muted",
    "audio-volume-low",
    "audio-volume-medium",
    "audio-volume-high",
    "audio-input-microphone-muted",
    "audio-input-microphone-low",
    "audio-input-microphone-medium",
    "audio-input-microphone-high".

Symbolic icons are the only way for themes to properly support
both light and dark panels with grey icons. If the icon name ends
with -symbolic, GTK renders the foreground color of the icon based
on the color of the panel behind it.

It's also important to use different icon names when it comes to
status icons, and not mix them with names which are also used for
notifications, menu items, and other aspects of the desktop.

There are two reasons for this:

- statusicons need to be rendered in specific sizes (typically, the presence
    of a scalable icon would create sizing issues in the systray, but could
    be required for notifications).

- full color icons might need to be rendered differently when notifications,
    menus and panels have a different shade within the same GTK theme (for
    instance with a light menu and a dark panel).

This also makes it more flexible for themes. They have the ability to
create symlinks if they want to, or to provide different icons for
panel, notifications and menus.

Ideally we should change the name of the full color icons as well,
but that would break support for existing themes, so I didn't do this
in this commit.