### PR TITLE
mate-volume-control: Fix 'syntax error' detected with 'cppcheck'

### DIFF
--- a/mate-volume-control/gvc-applet.c
+++ b/mate-volume-control/gvc-applet.c
@@ -115,7 +115,7 @@ update_icon_input (GvcApplet *applet)
                                         g_debug ("Found a recording application control %s",
                                                  mate_mixer_stream_control_get_label (input));
 
-                                        if G_UNLIKELY (control == NULL) {
+                                        if (G_UNLIKELY (control == NULL)) {
                                                 /* In the unlikely case when there is no
                                                  * default input control, use the application
                                                  * control for the icon */
@@ -130,7 +130,7 @@ update_icon_input (GvcApplet *applet)
                                     strcmp (app_id, "org.PulseAudio.pavucontrol") != 0) {
                                         g_debug ("Found a recording application %s", app_id);
 
-                                        if G_UNLIKELY (control == NULL)
+                                        if (G_UNLIKELY (control == NULL))
                                                 control = input;
 
                                         show = TRUE;
@@ -181,7 +181,7 @@ on_input_stream_control_added (MateMixerStream *stream,
         MateMixerStreamControl *control;
 
         control = mate_mixer_stream_get_control (stream, name);
-        if G_LIKELY (control != NULL) {
+        if (G_LIKELY (control != NULL)) {
                 MateMixerStreamControlRole role = mate_mixer_stream_control_get_role (control);
 
                 /* Non-application input control doesn't affect the icon */
@@ -284,10 +284,10 @@ gvc_applet_start (GvcApplet *applet)
 {
         g_return_if_fail (GVC_IS_APPLET (applet));
 
-        if G_UNLIKELY (applet->priv->running == TRUE)
+        if (G_UNLIKELY (applet->priv->running == TRUE))
                 return;
 
-        if G_UNLIKELY (mate_mixer_context_open (applet->priv->context) == FALSE) {
+        if (G_UNLIKELY (mate_mixer_context_open (applet->priv->context) == FALSE)) {
                 /* Normally this should never happen, in the worst case we
                  * should end up with the Null module */
                 g_warning ("Failed to connect to a sound system");

--- a/mate-volume-control/gvc-combo-box.c
+++ b/mate-volume-control/gvc-combo-box.c
@@ -108,7 +108,7 @@ on_switch_active_option_notify (MateMixerSwitch *swtch,
         const gchar           *name;
 
         active = mate_mixer_switch_get_active_option (swtch);
-        if G_UNLIKELY (active == NULL) {
+        if (G_UNLIKELY (active == NULL)) {
                 g_warn_if_reached ();
                 return;
         }
@@ -306,7 +306,7 @@ on_combo_box_changed (GtkComboBox *widget, GvcComboBox *combobox)
         gchar                 *name;
         MateMixerSwitchOption *option;
 
-        if G_UNLIKELY (gtk_combo_box_get_active_iter (GTK_COMBO_BOX (widget), &iter) == FALSE)
+        if (G_UNLIKELY (gtk_combo_box_get_active_iter (GTK_COMBO_BOX (widget), &iter) == FALSE))
                 return;
 
         gtk_tree_model_get (combobox->priv->model, &iter,
@@ -314,7 +314,7 @@ on_combo_box_changed (GtkComboBox *widget, GvcComboBox *combobox)
                             -1);
 
         option = mate_mixer_switch_get_option (combobox->priv->swtch, name);
-        if G_UNLIKELY (option == NULL) {
+        if (G_UNLIKELY (option == NULL)) {
                 g_warn_if_reached ();
                 g_free (name);
                 return;
@@ -425,7 +425,7 @@ gvc_combo_box_dispose (GObject *object)
 
         combobox = GVC_COMBO_BOX (object);
 
-        if G_LIKELY (combobox->priv->swtch != NULL) {
+        if (G_LIKELY (combobox->priv->swtch != NULL)) {
                 g_signal_handlers_disconnect_by_func (G_OBJECT (combobox->priv->swtch),
                                                       G_CALLBACK (on_switch_active_option_notify),
                                                       combobox);

--- a/mate-volume-control/gvc-mixer-dialog.c
+++ b/mate-volume-control/gvc-mixer-dialog.c
@@ -790,7 +790,7 @@ on_stream_control_added (MateMixerStream *stream,
         MateMixerStreamControlRole role;
 
         control = mate_mixer_stream_get_control (stream, name);
-        if G_UNLIKELY (control == NULL)
+        if (G_UNLIKELY (control == NULL))
                 return;
 
         role = mate_mixer_stream_control_get_role (control);

--- a/mate-volume-control/gvc-status-icon.c
+++ b/mate-volume-control/gvc-status-icon.c
@@ -104,7 +104,7 @@ update_icon_input (GvcStatusIcon *status_icon)
                                         g_debug ("Found a recording application control %s",
                                                  mate_mixer_stream_control_get_label (input));
 
-                                        if G_UNLIKELY (control == NULL) {
+                                        if (G_UNLIKELY (control == NULL)) {
                                                 /* In the unlikely case when there is no
                                                  * default input control, use the application
                                                  * control for the icon */
@@ -119,7 +119,7 @@ update_icon_input (GvcStatusIcon *status_icon)
                                     strcmp (app_id, "org.PulseAudio.pavucontrol") != 0) {
                                         g_debug ("Found a recording application %s", app_id);
 
-                                        if G_UNLIKELY (control == NULL)
+                                        if (G_UNLIKELY (control == NULL))
                                                 control = input;
 
                                         show = TRUE;
@@ -172,7 +172,7 @@ on_input_stream_control_added (MateMixerStream *stream,
         MateMixerStreamControl *control;
 
         control = mate_mixer_stream_get_control (stream, name);
-        if G_LIKELY (control != NULL) {
+        if (G_LIKELY (control != NULL)) {
                 MateMixerStreamControlRole role =
                         mate_mixer_stream_control_get_role (control);
 
@@ -277,10 +277,10 @@ gvc_status_icon_start (GvcStatusIcon *status_icon)
 {
         g_return_if_fail (GVC_IS_STATUS_ICON (status_icon));
 
-        if G_UNLIKELY (status_icon->priv->running == TRUE)
+        if (G_UNLIKELY (status_icon->priv->running == TRUE))
                 return;
 
-        if G_UNLIKELY (mate_mixer_context_open (status_icon->priv->context) == FALSE) {
+        if (G_UNLIKELY (mate_mixer_context_open (status_icon->priv->context) == FALSE)) {
                 /* Normally this should never happen, in the worst case we
                  * should end up with the Null module */
                 g_warning ("Failed to connect to a sound system");


### PR DESCRIPTION
Fixes cppcheck warnings:

```
[mate-volume-control/gvc-applet.c:118]: (error) syntax error
[mate-volume-control/gvc-applet.c:133]: (error) syntax error
[mate-volume-control/gvc-applet.c:184]: (error) syntax error
[mate-volume-control/gvc-applet.c:287]: (error) syntax error
[mate-volume-control/gvc-applet.c:290]: (error) syntax error

[mate-volume-control/gvc-combo-box.c:111]: (error) syntax error
[mate-volume-control/gvc-combo-box.c:309]: (error) syntax error
[mate-volume-control/gvc-combo-box.c:317]: (error) syntax error
[mate-volume-control/gvc-combo-box.c:428]: (error) syntax error

[mate-volume-control/gvc-mixer-dialog.c:793]: (error) syntax error

[mate-volume-control/gvc-status-icon.c:107]: (error) syntax error
[mate-volume-control/gvc-status-icon.c:122]: (error) syntax error
[mate-volume-control/gvc-status-icon.c:175]: (error) syntax error
[mate-volume-control/gvc-status-icon.c:280]: (error) syntax error
[mate-volume-control/gvc-status-icon.c:283]: (error) syntax error
```