### PR TITLE
mate-volume-control: reduce the scope of some variables

### DIFF
--- a/mate-volume-control/gvc-level-bar.c
+++ b/mate-volume-control/gvc-level-bar.c
@@ -569,9 +569,10 @@ gvc_level_bar_draw (GtkWidget *widget, cairo_t *cr)
 
         if (bar->priv->orientation == GTK_ORIENTATION_VERTICAL) {
                 int i;
-                int by;
 
                 for (i = 0; i < NUM_BOXES; i++) {
+                        int by;
+
                         by = i * bar->priv->layout.delta;
                         curved_rectangle (cr,
                                           bar->priv->layout.area.x + 0.5,
@@ -608,7 +609,6 @@ gvc_level_bar_draw (GtkWidget *widget, cairo_t *cr)
                 }
         } else {
                 int i;
-                int bx;
 
                 if (gtk_widget_get_direction (widget) == GTK_TEXT_DIR_RTL) {
                         GtkAllocation allocation;
@@ -620,6 +620,8 @@ gvc_level_bar_draw (GtkWidget *widget, cairo_t *cr)
                 }
 
                 for (i = 0; i < NUM_BOXES; i++) {
+                        int bx;
+
                         bx = i * bar->priv->layout.delta;
                         curved_rectangle (cr,
                                           bx + 0.5,

--- a/mate-volume-control/gvc-mixer-dialog.c
+++ b/mate-volume-control/gvc-mixer-dialog.c
@@ -376,13 +376,14 @@ static void
 set_output_stream (GvcMixerDialog *dialog, MateMixerStream *stream)
 {
         GtkTreeModel           *model;
-        MateMixerSwitch        *swtch;
         MateMixerStreamControl *control;
 
         control = gvc_channel_bar_get_control (GVC_CHANNEL_BAR (dialog->priv->output_bar));
         if (control != NULL) {
                 /* Disconnect port switch of the previous stream */
                 if (dialog->priv->output_port_combo != NULL) {
+                        MateMixerSwitch        *swtch;
+
                         swtch = g_object_get_data (G_OBJECT (dialog->priv->output_port_combo),
                                                    "switch");
                         if (swtch != NULL)
@@ -531,13 +532,14 @@ static void
 set_input_stream (GvcMixerDialog *dialog, MateMixerStream *stream)
 {
         GtkTreeModel           *model;
-        MateMixerSwitch        *swtch;
         MateMixerStreamControl *control;
 
         control = gvc_channel_bar_get_control (GVC_CHANNEL_BAR (dialog->priv->input_bar));
         if (control != NULL) {
                 /* Disconnect port switch of the previous stream */
                 if (dialog->priv->input_port_combo != NULL) {
+                        MateMixerSwitch        *swtch;
+
                         swtch = g_object_get_data (G_OBJECT (dialog->priv->input_port_combo),
                                                    "switch");
                         if (swtch != NULL)
@@ -1888,10 +1890,10 @@ gvc_mixer_dialog_constructor (GType                  type,
         GtkWidget        *ebox;
         GtkTreeSelection *selection;
         GtkAccelGroup    *accel_group;
-        GClosure         *closure;
         GtkTreeIter       iter;
         gint              i;
         const GList      *list;
+        GClosure         *closure = NULL;
 
         object = G_OBJECT_CLASS (gvc_mixer_dialog_parent_class)->constructor (type,
                                                                               n_construct_properties,

--- a/mate-volume-control/sound-theme-file-utils.c
+++ b/mate-volume-control/sound-theme-file-utils.c
@@ -44,9 +44,10 @@ char *
 custom_theme_dir_path (const char *child)
 {
         static char *dir = NULL;
-        const char *data_dir;
 
         if (dir == NULL) {
+                const char *data_dir;
+
                 data_dir = g_get_user_data_dir ();
                 dir = g_build_filename (data_dir, "sounds", CUSTOM_THEME_NAME, NULL);
         }


### PR DESCRIPTION
Fixes 'cppcheck' warnings:

```
[mate-volume-control/gvc-level-bar.c:572]: (style) The scope of the variable 'by' can be reduced.
[mate-volume-control/gvc-level-bar.c:611]: (style) The scope of the variable 'bx' can be reduced.

[mate-volume-control/gvc-mixer-dialog.c:379]: (style) The scope of the variable 'swtch' can be reduced.
[mate-volume-control/gvc-mixer-dialog.c:534]: (style) The scope of the variable 'swtch' can be reduced.
[mate-volume-control/gvc-mixer-dialog.c:1891]: (style) The scope of the variable 'closure' can be reduced.

[mate-volume-control/sound-theme-file-utils.c:47]: (style) The scope of the variable 'data_dir' can be reduced.
```