### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.60)
 
 AC_INIT([mate-media],
         [1.23.0],
-        [http://www.mate-desktop.org/])
+        [https://mate-desktop.org/])
 
 AC_CONFIG_AUX_DIR([build-aux])
 


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.