### PR TITLE
ci: set maximum compile warnings on step scan-build ./configure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,7 @@ variables:
 
 build_scripts:
   - ./autogen.sh --enable-compile-warnings=maximum
-  - scan-build $CHECKERS ./configure
+  - scan-build $CHECKERS ./configure --enable-compile-warnings=maximum
   - if [ $CPU_COUNT -gt 1 ]; then
   -     scan-build $CHECKERS --keep-cc -o html-report make -j $CPU_COUNT
   - else


### PR DESCRIPTION
The autogen.sh compiler warning flags are overridden in the configure step.