### PR TITLE
fix volume-panel-applet can not find mo file

### DIFF
--- a/mate-volume-control/Makefile.am
+++ b/mate-volume-control/Makefile.am
@@ -17,7 +17,7 @@ AM_CPPFLAGS = \
 	$(WARN_CFLAGS) \
 	$(VOLUME_CONTROL_CFLAGS) \
 	$(DISABLE_DEPRECATED) \
-	-DMATELOCALEDIR=\""$(prefix)/$(DATADIRNAME)/locale"\" \
+	-DMATELOCALEDIR=\""$(datadir)/locale"\" \
 	-DLOCALE_DIR=\""$(datadir)/locale"\" \
 	-DICON_DATA_DIR="\"$(pkgdatadir)/icons\"" \
 	-DSOUND_SET_DIR="\"$(pkgdatadir)/sounds\"" \


### PR DESCRIPTION
Before PR:
![volume-applet-menu](https://user-images.githubusercontent.com/961604/68995354-26a54e00-088d-11ea-87d3-9c2777c5b918.jpg)

Please test.

Edit: Note, only the panel-applet has this issue, menu of tray-applet looks good.