### PR TITLE
Fix desktop file validation warnings

### DIFF
--- a/data/mate-volume-control.desktop.in.in
+++ b/data/mate-volume-control.desktop.in.in
@@ -7,7 +7,7 @@ Icon=multimedia-volume-control
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=AudioVideo;Mixer;Settings;HardwareSettings;
+Categories=GTK;AudioVideo;Audio;Mixer;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=MATE;volume;control;mixer;settings;sound;events;
 OnlyShowIn=MATE;


### PR DESCRIPTION
```
$ desktop-file-validate ./data/mate-volume-control.desktop
./data/mate-volume-control.desktop: hint: value item "Mixer" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: AudioVideo;Audio
./data/mate-volume-control.desktop: hint: value "AudioVideo;Mixer;Settings;HardwareSettings;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu
```
https://specifications.freedesktop.org/menu-spec/latest/apas02.html