### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/mate-volume-control/dialog-main.c
+++ b/mate-volume-control/dialog-main.c
@@ -192,7 +192,7 @@ main (int argc, char **argv)
                 { "debug",   'd', 0, G_OPTION_ARG_NONE,   &debug, N_("Enable debug"), NULL },
                 { "page",    'p', 0, G_OPTION_ARG_STRING, &page, N_("Startup page"), "effects|hardware|input|output|applications" },
                 { "version", 'v', 0, G_OPTION_ARG_NONE,   &show_version, N_("Version of this application"), NULL },
-                { NULL }
+                { NULL,        0, 0, G_OPTION_ARG_NONE,   NULL, NULL, NULL }
         };
 
         bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);

--- a/mate-volume-control/status-icon-main.c
+++ b/mate-volume-control/status-icon-main.c
@@ -45,7 +45,7 @@ main (int argc, char **argv)
         GOptionEntry   entries[] = {
                 { "version", 'v', 0, G_OPTION_ARG_NONE, &show_version, N_("Version of this application"), NULL },
                 { "debug", 'd', 0, G_OPTION_ARG_NONE, &debug, N_("Enable debug"), NULL },
-                { NULL }
+                { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
         };
 
         bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);


### PR DESCRIPTION
```
status-icon-main.c:48:24: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                { NULL }
                       ^
--
dialog-main.c:195:24: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                { NULL }
                       ^
```