### PR TITLE
gvc-stream-applet-icon: fix memory leak

### DIFF
--- a/mate-volume-control/gvc-stream-applet-icon.c
+++ b/mate-volume-control/gvc-stream-applet-icon.c
@@ -763,6 +763,7 @@ gvc_stream_applet_icon_finalize (GObject *object)
         icon = GVC_STREAM_APPLET_ICON (object);
 
         g_strfreev (icon->priv->icon_names);
+        g_clear_pointer (&icon->priv->display_name, g_free);
 
         g_signal_handlers_disconnect_by_func (gtk_settings_get_default (),
                                               on_icon_theme_change,


### PR DESCRIPTION
```
Direct leak of 7 byte(s) in 1 object(s) allocated from:
    #0 0x7fd32d49693f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fd32beb11bf in g_malloc ../glib/gmem.c:106
    #2 0x7fd32beb1502 in g_malloc_n ../glib/gmem.c:344
    #3 0x7fd32bed3995 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x409bfa in gvc_stream_applet_icon_set_display_name /home/robert/builddir.gcc/mate-media/mate-volume-control/gvc-stream-applet-icon.c:504
    #5 0x40ce8b in gvc_applet_init /home/robert/builddir.gcc/mate-media/mate-volume-control/gvc-applet.c:403
    #6 0x7fd32bfe3623 in g_type_create_instance ../gobject/gtype.c:1929
    #7 0x7fd32bfc8bd4 in g_object_new_internal ../gobject/gobject.c:1945
    #8 0x7fd32bfc8170 in g_object_new_with_properties ../gobject/gobject.c:2114
    #9 0x7fd32bfc7ef3 in g_object_new ../gobject/gobject.c:1785
    #10 0x40d214 in gvc_applet_new /home/robert/builddir.gcc/mate-media/mate-volume-control/gvc-applet.c:430
    #11 0x40e58f in applet_main /home/robert/builddir.gcc/mate-media/mate-volume-control/applet-main.c:68
    #12 0x40e641 in applet_factory /home/robert/builddir.gcc/mate-media/mate-volume-control/applet-main.c:85
    #13 0x7fd32cf96673 in mate_panel_applet_marshal_BOOLEAN__STRING /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet-marshal.c:122
    #14 0x7fd32bfbe354 in g_closure_invoke ../gobject/gclosure.c:830
    #15 0x7fd32cf9ec00 in mate_panel_applet_setup /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet.c:1814
    #16 0x7fd32bfc20f7 in g_cclosure_marshal_VOID__VOIDv ../gobject/gmarshal.c:165
    #17 0x7fd32bfbe770 in _g_closure_invoke_va ../gobject/gclosure.c:893
    #18 0x7fd32bfdf972 in g_signal_emit_valist ../gobject/gsignal.c:3406
    #19 0x7fd32bfe10e1 in g_signal_emit_by_name ../gobject/gsignal.c:3594
    #20 0x7fd32c9f980c in gtk_plug_filter_func (/lib64/libgtk-3.so.0+0x3e480c)
```