### PR TITLE
Fix build warning -Wbad-function-cast

### DIFF
--- a/mate-volume-control/gvc-channel-bar.c
+++ b/mate-volume-control/gvc-channel-bar.c
@@ -24,6 +24,7 @@
 
 #include <sys/param.h>
 
+#include <math.h>
 #include <glib.h>
 #include <glib/gi18n.h>
 #include <glib-object.h>
@@ -447,9 +448,10 @@ on_scale_button_press_event (GtkWidget      *widget,
         if (bar->priv->control_flags & MATE_MIXER_STREAM_CONTROL_MUTE_READABLE &&
             bar->priv->control_flags & MATE_MIXER_STREAM_CONTROL_VOLUME_READABLE) {
                 if (mate_mixer_stream_control_get_mute (bar->priv->control) == TRUE) {
-                        guint minimum = (guint) gtk_adjustment_get_lower (bar->priv->adjustment);
+                        double minimum;
 
-                        if (mate_mixer_stream_control_get_volume (bar->priv->control) > minimum)
+                        minimum = gtk_adjustment_get_lower (bar->priv->adjustment);
+                        if (mate_mixer_stream_control_get_volume (bar->priv->control) > (guint) minimum)
                                 bar->priv->click_lock = TRUE;
                 }
         }

--- a/mate-volume-control/gvc-stream-applet-icon.c
+++ b/mate-volume-control/gvc-stream-applet-icon.c
@@ -337,6 +337,7 @@ static void
 update_icon (GvcStreamAppletIcon *icon)
 {
         guint                       volume = 0;
+        guint                       volume_percent;
         gdouble                     decibel = 0;
         guint                       normal = 0;
         gboolean                    muted = FALSE;
@@ -380,7 +381,7 @@ update_icon (GvcStreamAppletIcon *icon)
 
         description = mate_mixer_stream_control_get_label (icon->priv->control);
 
-        guint volume_percent = (guint) round (100.0 * volume / normal);
+        volume_percent = (normal == 0) ? 0 : MIN ((100 * volume) / normal, 100);
         if (muted) {
                 markup = g_strdup_printf ("<b>%s: %s %u%%</b>\n<small>%s</small>",
                                           icon->priv->display_name,

--- a/mate-volume-control/gvc-stream-status-icon.c
+++ b/mate-volume-control/gvc-stream-status-icon.c
@@ -380,6 +380,7 @@ static void
 update_icon (GvcStreamStatusIcon *icon)
 {
         guint                volume = 0;
+        guint                volume_percent;
         gdouble              decibel = 0;
         guint                normal = 0;
         gboolean             muted = FALSE;
@@ -424,7 +425,7 @@ update_icon (GvcStreamStatusIcon *icon)
 
         description = mate_mixer_stream_control_get_label (icon->priv->control);
 
-        guint volume_percent = (guint) round (100.0 * volume / normal);
+        volume_percent = (normal == 0) ? 0 : MIN ((100 * volume) / normal, 100);
         if (muted) {
                 markup = g_strdup_printf ("<b>%s: %s %u%%</b>\n<small>%s</small>",
                                           icon->priv->display_name,


### PR DESCRIPTION
```
CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> mate-media.make.log
grep -A 2 "Wbad-function-cast]" mate-media.make.log 
```
Fix the build warnings below:
```
gvc-stream-status-icon.c:427:40: warning: cast from function call of type 'double' to non-matching type 'guint' (aka 'unsigned int') [-Wbad-function-cast]
        guint volume_percent = (guint) round (100.0 * volume / normal);
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
gvc-channel-bar.c:450:49: warning: cast from function call of type 'gdouble' (aka 'double') to non-matching type 'guint' (aka 'unsigned int') [-Wbad-function-cast]
                        guint minimum = (guint) gtk_adjustment_get_lower (bar->priv->adjustment);
                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
gvc-stream-applet-icon.c:383:40: warning: cast from function call of type 'double' to non-matching type 'guint' (aka 'unsigned int') [-Wbad-function-cast]
        guint volume_percent = (guint) round (100.0 * volume / normal);
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```