### PR TITLE
sound-theme-file-utils: fix build warning -Wformat-nonliteral

### DIFF
--- a/mate-volume-control/sound-theme-file-utils.c
+++ b/mate-volume-control/sound-theme-file-utils.c
@@ -187,12 +187,12 @@ custom_theme_dir_is_empty (void)
 }
 
 static void
-delete_one_file (const char *sound_name, const char *pattern)
+delete_one_file (const char *sound_name, const char *file_extension)
 {
         GFile *file;
         char *name, *filename;
 
-        name = g_strdup_printf (pattern, sound_name);
+        name = g_strconcat (sound_name, file_extension, NULL);
         filename = custom_theme_dir_path (name);
         g_free (name);
         file = g_file_new_for_path (filename);
@@ -207,7 +207,7 @@ delete_old_files (const char **sounds)
         guint i;
 
         for (i = 0; sounds[i] != NULL; i++) {
-                delete_one_file (sounds[i], "%s.ogg");
+                delete_one_file (sounds[i], ".ogg");
         }
 }
 
@@ -217,7 +217,7 @@ delete_disabled_files (const char **sounds)
         guint i;
 
         for (i = 0; sounds[i] != NULL; i++)
-                delete_one_file (sounds[i], "%s.disabled");
+                delete_one_file (sounds[i], ".disabled");
 }
 
 static void


### PR DESCRIPTION
```
CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
Fix the build warning below:
```
sound-theme-file-utils.c:195:33: warning: format string is not a string literal [-Wformat-nonliteral]
        name = g_strdup_printf (pattern, sound_name);
                                ^~~~~~~
```