### PR TITLE
Fix warnings -Wfloat-conversion, -Wimplicit-float-conversion

### DIFF
--- a/mate-volume-control/gvc-balance-bar.c
+++ b/mate-volume-control/gvc-balance-bar.c
@@ -482,15 +482,17 @@ on_adjustment_value_changed (GtkAdjustment *adjustment, GvcBalanceBar *bar)
 
         switch (bar->priv->btype) {
         case BALANCE_TYPE_RL:
-                mate_mixer_stream_control_set_balance (bar->priv->control, value);
+                mate_mixer_stream_control_set_balance (bar->priv->control,
+                                                       (gfloat) value);
                 break;
         case BALANCE_TYPE_FR:
-                mate_mixer_stream_control_set_fade (bar->priv->control, value);
+                mate_mixer_stream_control_set_fade (bar->priv->control,
+                                                    (gfloat) value);
                 break;
         case BALANCE_TYPE_LFE:
                 mate_mixer_stream_control_set_channel_volume (bar->priv->control,
-                                                      bar->priv->lfe_channel,
-                                                      value);
+                                                              bar->priv->lfe_channel,
+                                                              (guint) value);
                 break;
         }
 }

--- a/mate-volume-control/gvc-level-bar.c
+++ b/mate-volume-control/gvc-level-bar.c
@@ -150,8 +150,8 @@ reset_max_peak (GvcLevelBar *bar)
 static void
 bar_calc_layout (GvcLevelBar *bar)
 {
-        int           peak_level;
-        int           max_peak_level;
+        gdouble       peak_level;
+        gdouble       max_peak_level;
         GtkAllocation allocation;
 
         GtkStyleContext *context;
@@ -179,8 +179,8 @@ bar_calc_layout (GvcLevelBar *bar)
         bar->priv->layout.area.height = allocation.height - 2;
 
         if (bar->priv->orientation == GTK_ORIENTATION_VERTICAL) {
-                peak_level = bar->priv->peak_fraction * bar->priv->layout.area.height;
-                max_peak_level = bar->priv->max_peak * bar->priv->layout.area.height;
+                peak_level = bar->priv->peak_fraction * (gdouble) bar->priv->layout.area.height;
+                max_peak_level = bar->priv->max_peak * (gdouble) bar->priv->layout.area.height;
 
                 bar->priv->layout.delta = bar->priv->layout.area.height / NUM_BOXES;
                 bar->priv->layout.area.x = 0;
@@ -189,8 +189,8 @@ bar_calc_layout (GvcLevelBar *bar)
                 bar->priv->layout.box_width  = bar->priv->layout.area.width;
                 bar->priv->layout.box_radius = bar->priv->layout.box_width / 2;
         } else {
-                peak_level = bar->priv->peak_fraction * bar->priv->layout.area.width;
-                max_peak_level = bar->priv->max_peak * bar->priv->layout.area.width;
+                peak_level = bar->priv->peak_fraction * (gdouble) bar->priv->layout.area.width;
+                max_peak_level = bar->priv->max_peak * (gdouble) bar->priv->layout.area.width;
 
                 bar->priv->layout.delta = bar->priv->layout.area.width / NUM_BOXES;
                 bar->priv->layout.area.x = 0;
@@ -200,8 +200,8 @@ bar_calc_layout (GvcLevelBar *bar)
                 bar->priv->layout.box_radius = bar->priv->layout.box_height / 2;
         }
 
-        bar->priv->layout.peak_num = peak_level / bar->priv->layout.delta;
-        bar->priv->layout.max_peak_num = max_peak_level / bar->priv->layout.delta;
+        bar->priv->layout.peak_num = (int) (peak_level / (gdouble) bar->priv->layout.delta);
+        bar->priv->layout.max_peak_num = (int) (max_peak_level / (gdouble) bar->priv->layout.delta);
 }
 
 static void
@@ -524,7 +524,7 @@ curved_rectangle (cairo_t *cr,
         x1 = x0 + width;
         y1 = y0 + height;
 
-        if (!width || !height)
+        if (width == 0.0 || height == 0.0)
                 return;
 
         if (width / 2 < radius) {


### PR DESCRIPTION
```
CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
Fix the build warnings below:
```
gvc-balance-bar.c:485:76: warning: implicit conversion loses floating-point precision: 'gdouble' (aka 'double') to 'gfloat' (aka 'float') [-Wimplicit-float-conversion]
                mate_mixer_stream_control_set_balance (bar->priv->control, value);
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                      ^~~~~
gvc-balance-bar.c:488:73: warning: implicit conversion loses floating-point precision: 'gdouble' (aka 'double') to 'gfloat' (aka 'float') [-Wimplicit-float-conversion]
                mate_mixer_stream_control_set_fade (bar->priv->control, value);
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                      ^~~~~
gvc-balance-bar.c:493:55: warning: implicit conversion turns floating-point number into integer: 'gdouble' (aka 'double') to 'guint' (aka 'unsigned int') [-Wfloat-conversion]
                                                      value);
                                                      ^~~~~
--
gvc-level-bar.c:182:55: warning: implicit conversion turns floating-point number into integer: 'double' to 'int' [-Wfloat-conversion]
                peak_level = bar->priv->peak_fraction * bar->priv->layout.area.height;
                           ~ ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gvc-level-bar.c:183:54: warning: implicit conversion turns floating-point number into integer: 'double' to 'int' [-Wfloat-conversion]
                max_peak_level = bar->priv->max_peak * bar->priv->layout.area.height;
                               ~ ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gvc-level-bar.c:192:55: warning: implicit conversion turns floating-point number into integer: 'double' to 'int' [-Wfloat-conversion]
                peak_level = bar->priv->peak_fraction * bar->priv->layout.area.width;
                           ~ ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gvc-level-bar.c:193:54: warning: implicit conversion turns floating-point number into integer: 'double' to 'int' [-Wfloat-conversion]
                max_peak_level = bar->priv->max_peak * bar->priv->layout.area.width;
                               ~ ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
gvc-level-bar.c:527:24: warning: implicit conversion turns floating-point number into integer: 'double' to '_Bool' [-Wfloat-conversion]
        if (!width || !height)
                      ~^~~~~~
gvc-level-bar.c:527:14: warning: implicit conversion turns floating-point number into integer: 'double' to '_Bool' [-Wfloat-conversion]
        if (!width || !height)
            ~^~~~~
```