### PR TITLE
gvc-balance-bar: fix build warning -Wunused-macros

### DIFF
--- a/mate-volume-control/gvc-balance-bar.c
+++ b/mate-volume-control/gvc-balance-bar.c
@@ -30,12 +30,6 @@
 
 #include "gvc-balance-bar.h"
 
-#define BALANCE_BAR_STYLE                                       \
-        "style \"balance-bar-scale-style\" {\n"                 \
-        " GtkScale::trough-side-details = 0\n"                  \
-        "}\n"                                                   \
-        "widget \"*.balance-bar-scale\" style : rc \"balance-bar-scale-style\"\n"
-
 #define SCALE_SIZE 128
 
 struct _GvcBalanceBarPrivate


### PR DESCRIPTION
```
CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
Fix the build warning below:
```
gvc-balance-bar.c:33:9: warning: macro is not used [-Wunused-macros]
#define BALANCE_BAR_STYLE                                       \
        ^
```