### PR TITLE
Add setting for adjustment of audio volume above 100 per cent:  Part 2

### DIFF
--- a/mate-volume-control/gvc-channel-bar.h
+++ b/mate-volume-control/gvc-channel-bar.h
@@ -95,6 +95,10 @@ gboolean            gvc_channel_bar_get_show_marks      (GvcChannelBar      *bar
 void                gvc_channel_bar_set_show_marks      (GvcChannelBar      *bar,
                                                          gboolean            show_marks);
 
+gboolean            gvc_channel_bar_get_show_mark_text  (GvcChannelBar      *bar);
+void                gvc_channel_bar_set_show_mark_text  (GvcChannelBar      *bar,
+                                                         gboolean            show_mark_text);
+
 gboolean            gvc_channel_bar_get_extended        (GvcChannelBar      *bar);
 void                gvc_channel_bar_set_extended        (GvcChannelBar      *bar,
                                                          gboolean            extended);

--- a/mate-volume-control/gvc-stream-applet-icon.c
+++ b/mate-volume-control/gvc-stream-applet-icon.c
@@ -37,6 +37,7 @@
 
 struct _GvcStreamAppletIconPrivate
 {
+        GSettings              *sound_settings;
         gchar                 **icon_names;
         GtkImage               *image;
         GtkWidget              *dock;
@@ -680,6 +681,8 @@ gvc_stream_applet_icon_init (GvcStreamAppletIcon *icon)
 
         icon->priv = gvc_stream_applet_icon_get_instance_private (icon);
 
+        icon->priv->sound_settings = g_settings_new ("org.mate.sound");
+
         icon->priv->image = GTK_IMAGE (gtk_image_new ());
         gtk_container_add (GTK_CONTAINER (icon), GTK_WIDGET (icon->priv->image));
 
@@ -731,6 +734,17 @@ gvc_stream_applet_icon_init (GvcStreamAppletIcon *icon)
         gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar),
                                          GTK_ORIENTATION_VERTICAL);
 
+        gvc_channel_bar_set_show_mark_text (GVC_CHANNEL_BAR (icon->priv->bar),
+                                            FALSE);
+
+        g_settings_bind (icon->priv->sound_settings, "volume-overamplifiable",
+                         icon->priv->bar,            "show-marks",
+                         G_SETTINGS_BIND_GET);
+
+        g_settings_bind (icon->priv->sound_settings, "volume-overamplifiable",
+                         icon->priv->bar,            "extended",
+                         G_SETTINGS_BIND_GET);
+
         /* Set volume control frame, slider and toplevel window to follow panel theme */
         GtkWidget *toplevel = gtk_widget_get_toplevel (icon->priv->dock);
         GtkStyleContext *context;
@@ -768,6 +782,8 @@ gvc_stream_applet_icon_finalize (GObject *object)
         g_signal_handlers_disconnect_by_func (gtk_settings_get_default (),
                                               on_icon_theme_change,
                                               icon);
+
+        g_clear_object (&icon->priv->sound_settings);
 
         G_OBJECT_CLASS (gvc_stream_applet_icon_parent_class)->finalize (object);
 }

--- a/mate-volume-control/gvc-stream-status-icon.c
+++ b/mate-volume-control/gvc-stream-status-icon.c
@@ -35,6 +35,7 @@
 
 struct _GvcStreamStatusIconPrivate
 {
+        GSettings       *sound_settings;
         gchar          **icon_names;
         GtkWidget       *dock;
         GtkWidget       *bar;
@@ -689,6 +690,8 @@ gvc_stream_status_icon_init (GvcStreamStatusIcon *icon)
 
         icon->priv = gvc_stream_status_icon_get_instance_private (icon);
 
+        icon->priv->sound_settings = g_settings_new ("org.mate.sound");
+
         g_signal_connect (G_OBJECT (icon),
                           "activate",
                           G_CALLBACK (on_status_icon_activate),
@@ -745,6 +748,17 @@ gvc_stream_status_icon_init (GvcStreamStatusIcon *icon)
         gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar),
                                          GTK_ORIENTATION_VERTICAL);
 
+        gvc_channel_bar_set_show_mark_text (GVC_CHANNEL_BAR (icon->priv->bar),
+                                            FALSE);
+
+        g_settings_bind (icon->priv->sound_settings, "volume-overamplifiable",
+                         icon->priv->bar,            "show-marks",
+                         G_SETTINGS_BIND_GET);
+
+        g_settings_bind (icon->priv->sound_settings, "volume-overamplifiable",
+                         icon->priv->bar,            "extended",
+                         G_SETTINGS_BIND_GET);
+
         /* Set volume control frame, slider and toplevel window to follow panel theme */
         GtkWidget *toplevel = gtk_widget_get_toplevel (icon->priv->dock);
         GtkStyleContext *context;
@@ -780,6 +794,8 @@ gvc_stream_status_icon_finalize (GObject *object)
         g_signal_handlers_disconnect_by_func (gtk_settings_get_default (),
                                               on_icon_theme_change,
                                               icon);
+
+        g_clear_object (&icon->priv->sound_settings);
 
         G_OBJECT_CLASS (gvc_stream_status_icon_parent_class)->finalize (object);
 }


### PR DESCRIPTION
There is often a need for the user to increase the audio playback volume above
the volume level known as "100% volume".  While increasing the audio volume
above 100% can result in degraded audio quality, sometimes the audio was, for
example, originally recorded at an extremely low volume, and the user has no
other option to clearly hear the audio.  Unfortunately, most MATE applications
with volume controls do not allow the user to set the volume level above 100%.
For example, the main MATE Sound Preferences dialog lets you set the audio
volume beyond 100% (when possible), whereas the Volume Control Applet, Volume
Control status icon, and special "multimedia" volume control keys do not.  In
fact, if the user even tries to change the volume using any of the latter
methods, and the current volume level is above 100%, these latter methods will
all reduce the volume to 100%, even if the user tried to increase the volume!

This is part 2 of a patch to change this situation.  This patch adds this
capability to the MATE Volume Control Applet and the MATE Volume Control
status icon.  It also adds a check box to the MATE Volume Control Preferences
dialog to enable or disable this capability, and for consistency, the main
volume control at the top of that dialog also obeys the current setting of
that check box.  This commit is by far the largest one, and is the main part
of the patch.

Part 1:  https://github.com/mate-desktop/mate-desktop/pull/530
Part 3:  https://github.com/mate-desktop/mate-settings-daemon/pull/389

When all three parts are applied, https://github.com/mate-desktop/mate-desktop/issues/246 can be closed.