### PR TITLE
gvc-stream-status-icon: fix a volume rounding error (101% -> 100%)

### DIFF
--- a/mate-volume-control/gvc-channel-bar.c
+++ b/mate-volume-control/gvc-channel-bar.c
@@ -369,18 +369,11 @@ update_adjustment_value (GvcChannelBar *bar)
         else
                 value = mate_mixer_stream_control_get_volume (bar->priv->control);
 
-        gdouble maximum = gtk_adjustment_get_upper (bar->priv->adjustment);
-        gdouble minimum = gtk_adjustment_get_lower (bar->priv->adjustment);
-        gdouble range = maximum - minimum;
-
-        /* round value to nearest hundreth of the range */
-        gdouble new_value = minimum + round (((value - minimum) / range) * 100) * (range / 100);
-
         g_signal_handlers_block_by_func (G_OBJECT (bar->priv->adjustment),
                                          on_adjustment_value_changed,
                                          bar);
 
-        gtk_adjustment_set_value (bar->priv->adjustment, new_value);
+        gtk_adjustment_set_value (bar->priv->adjustment, value);
 
         g_signal_handlers_unblock_by_func (G_OBJECT (bar->priv->adjustment),
                                            on_adjustment_value_changed,

--- a/mate-volume-control/gvc-stream-status-icon.c
+++ b/mate-volume-control/gvc-stream-status-icon.c
@@ -380,6 +380,7 @@ static void
 update_icon (GvcStreamStatusIcon *icon)
 {
         guint                volume = 0;
+        guint                volume_percent = 0;
         gdouble              decibel = 0;
         guint                normal = 0;
         gboolean             muted = FALSE;
@@ -407,7 +408,7 @@ update_icon (GvcStreamStatusIcon *icon)
 
                 /* Select an icon, they are expected to be sorted, the lowest index being
                  * the mute icon and the rest being volume increments */
-                if (volume <= 0 || muted)
+                if (volume == 0 || muted)
                         n = 0;
                 else
                         n = CLAMP (3 * volume / normal + 1, 1, 3);
@@ -424,7 +425,9 @@ update_icon (GvcStreamStatusIcon *icon)
 
         description = mate_mixer_stream_control_get_label (icon->priv->control);
 
-        guint volume_percent = (guint) round (100.0 * volume / normal);
+        if (normal != 0)
+                volume_percent = (guint) (100.0 * ((double) volume) / ((double) normal));
+
         if (muted) {
                 markup = g_strdup_printf ("<b>%s: %s %u%%</b>\n<small>%s</small>",
                                           icon->priv->display_name,


### PR DESCRIPTION
### Before
<img width="571" alt="Captura de pantalla 2022-08-03 a les 10 36 46" src="https://user-images.githubusercontent.com/10171411/182563579-ae1ee0f4-247d-4e3d-8fdc-b9e369de4955.png">

### After
<img width="601" alt="Captura de pantalla 2022-08-03 a les 12 30 44" src="https://user-images.githubusercontent.com/10171411/182587247-8a57638f-58d4-4ebb-bfe3-a12aa3cf818a.png">


Value of the variables when the volume is set to 100% (0 db):
- volume = normal = 65536
- volume_percent = 100
- decibel = 0

<img width="1265" alt="Captura de pantalla 2022-08-03 a les 13 40 55" src="https://user-images.githubusercontent.com/10171411/182599403-40482df6-35c4-463e-86c2-2b4d70ed6922.png">

It reverts the commit b005276f2bb281b1bc2d1ef4ba18cdd43294d58f