### PR TITLE
position popup slider properly in wayland and make wayland optional

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -29,6 +29,7 @@ requires:
     - libcanberra-gtk3-dev
     - libglib2.0-dev
     - libgtk-3-dev
+    - libgtk-layer-shell-dev
     - libmate-desktop-dev
     - libmate-panel-applet-dev
     - libmatemixer-dev
@@ -46,6 +47,7 @@ requires:
     - desktop-file-utils
     - git
     - gtk3-devel
+    - gtk-layer-shell-devel
     - libmatemixer-devel
     - libxml2-devel
     - libcanberra-devel
@@ -65,6 +67,7 @@ requires:
     - libcanberra-gtk3-dev
     - libglib2.0-dev
     - libgtk-3-dev
+    - libgtk-layer-shell-dev
     - libmate-desktop-dev
     - libmate-panel-applet-dev
     - libmatemixer-dev

--- a/configure.ac
+++ b/configure.ac
@@ -238,7 +238,7 @@ if test "x$enable_panelapplet" = "xno"; then
 else
 	echo "    Building panel applet ......: yes"
 fi
-echo "    Building in-process ......: $enable_in_process"
-echo "    Wayland support ..........: $enable_wayland"
+echo "    Building in-process ........: $enable_in_process"
+echo "    Wayland support ............: $enable_wayland"
 #get a newline in the terminal
 echo ""

--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,13 @@ if test "x$enable_deprecated" = "xyes"; then
     AC_SUBST(DISABLE_DEPRECATED)
 fi
 
+AC_DEFINE(HAVE_WAYLAND, 1, [Have the Wayland development library])
+
+
+AC_SUBST(WAYLAND_CFLAGS)
+AC_SUBST(WAYLAND_LIBS)
+
+
 #============================================================================
 # status icon
 #============================================================================
@@ -123,6 +130,43 @@ else
 fi
 AM_CONDITIONAL(ENABLE_PANELAPPLET, test "x$enable_panelapplet" != "xno")
 
+dnl Whether to build the volume control applet in-process
+dnl --
+
+AC_ARG_ENABLE(in-process, [AS_HELP_STRING([--enable-in-process], [Enable in-process build of panel applet (default: yes, forced if wayland enabled)])],,[enable_in-process=yes] [in-process is forced if wayland support is enabled])
+if test "x$enable_panelapplet" = "xno"; then
+    AC_DEFINE(ENABLE_IN_PROCESS, 0, [Enable if you want to build the panel applet in-process])
+else
+    AC_DEFINE(ENABLE_IN_PROCESS, 1, [Enable if you want to build the panel applet in-process])
+fi
+
+AC_ARG_ENABLE(wayland,
+              [AS_HELP_STRING([--enable-wayland],
+                              [Explicitly enable or disable Wayland support
+                              (default is to enable only if Wayland client development library is detected)])],
+              [enable_wayland=$enableval],
+              [enable_wayland=auto])
+
+# Check if we have gtk-layer-shell installed, and thus should build with Wayland support
+have_wayland=no
+if test "x$enable_wayland" != "xno"; then
+  PKG_CHECK_MODULES(WAYLAND, gtk-layer-shell-0 wayland-client, have_wayland=yes, [
+        if test "x$enable_wayland" = "xyes"; then
+          AC_MSG_ERROR([Wayland enabled but GTK Layer Shell library not found])
+        fi
+    ])
+fi
+
+AM_CONDITIONAL(ENABLE_WAYLAND, test "x$enable_wayland" != "xno")
+if test "x$enable_wayland" = "xno"; then
+    AC_DEFINE(ENABLE_WAYLAND, 0, [Enable if you want to build the panel applet with wayland support])
+else
+    AC_DEFINE(ENABLE_WAYLAND, 1, [Enable if you want to build the panel applet with wayland support])
+    AC_DEFINE(ENABLE_IN_PROCESS, 1, [in-process required for wayland support])
+    AC_SUBST(WAYLAND_CFLAGS)
+    AC_SUBST(WAYLAND_LIBS)
+fi
+
 #============================================================================
 # Sanity check: must build either status icon or panel applet
 #============================================================================
@@ -153,6 +197,10 @@ po/Makefile.in
 mate-volume-control/Makefile
 ])
 
+if test "x$have_wayland" = "xyes"; then
+  AC_DEFINE(HAVE_WAYLAND)
+fi
+
 AC_OUTPUT
 
 echo "
@@ -175,11 +223,20 @@ if test "x$enable_statusicon" = "xno"; then
 else
 	echo "    Building status icon .......: yes"
 fi
-
 if test "x$enable_panelapplet" = "xno"; then
 	echo "    Building panel applet ......: no"
-else
+else 
 	echo "    Building panel applet ......: yes"
+fi
+if test "x$enable_in_process" = "xno"; then
+	echo "    Building in-process .......: no"
+else
+	echo "    Building in-process .......: yes"
+fi
+if test "x$enable_wayland" = "xno"; then
+	echo "    Building with wayland support .......: no"
+else
+	echo "    Building with wayland support .......: yes"
 fi
 #get a newline in the terminal
 echo ""

--- a/configure.ac
+++ b/configure.ac
@@ -91,13 +91,6 @@ if test "x$enable_deprecated" = "xyes"; then
     AC_SUBST(DISABLE_DEPRECATED)
 fi
 
-AC_DEFINE(HAVE_WAYLAND, 1, [Have the Wayland development library])
-
-
-AC_SUBST(WAYLAND_CFLAGS)
-AC_SUBST(WAYLAND_LIBS)
-
-
 #============================================================================
 # status icon
 #============================================================================
@@ -130,62 +123,54 @@ else
 fi
 AM_CONDITIONAL(ENABLE_PANELAPPLET, test "x$enable_panelapplet" != "xno")
 
-dnl Whether to build the volume control applet in-process
-dnl --
+#============================================================================
+# applet in-process and Wayland support
+#============================================================================
 
-AC_ARG_ENABLE(in-process, [AS_HELP_STRING([--enable-in-process], [Enable in-process build of panel applet (default: yes, required for wayland)])],,[enable_in-process=yes])
-
-AM_CONDITIONAL(IN_PROCESS, test "x$enable_in_process" != "xno")
-if test "x$enable_in_process" != "xno"; then
-    AC_DEFINE(IN_PROCESS, 1, [Enable if you want to build the panel applet in-process])
-fi
-
-AC_STRUCT_DIRENT_D_TYPE
-
-# $$enable_wayland will be set to "yes", "no" or "auto"
-
-AC_ARG_ENABLE(wayland,
+AC_ARG_ENABLE([wayland],
               [AS_HELP_STRING([--enable-wayland],
                               [Explicitly enable or disable Wayland support
-                              (default is to enable only if Wayland client development library is detected)])],
+                               (default is to enable only if Wayland client development library is detected)])],
               [enable_wayland=$enableval],
               [enable_wayland=auto])
+AC_ARG_ENABLE([in-process],
+              [AS_HELP_STRING([--enable-in-process],
+                              [Enable in-process build of panel applet (default: no, required for wayland)])],
+              [enable_in_process=$enableval],
+              [dnl the default follows whether Wayland is requested or not,
+               dnl as Wayland support requires it but we d rather not have it
+               dnl otherwise for the moment
+               enable_in_process=$enable_wayland])
 
-# Check if we have gtk-layer-shell installed, and thus should build with Wayland support
-have_wayland=no
-if test "x$enable_wayland" != "xno"; then
-  PKG_CHECK_MODULES(WAYLAND, gtk-layer-shell-0 wayland-client, have_wayland=yes, [
-        if test "x$enable_wayland" = "xyes"; then
-          AC_MSG_ERROR([Wayland enabled but GTK Layer Shell library not found])
-        fi
-    ])
-fi
+dnl $enable_in_process is gonna be either:
+dnl - "no" if explicitly disabled
+dnl - "yes" if explicitly enabled or if Wayland is explicitly enabled
+dnl - "auto" if nothing specific is requested, in which case, default back to "no"
+AS_IF([test "x$enable_in_process" != xyes], [enable_in_process=no])
 
-AM_CONDITIONAL(HAVE_WAYLAND, [test "x$have_wayland" = "xyes"])
+WAYLAND_DEPS="gtk-layer-shell-0 wayland-client"
+AS_CASE(["x$enable_wayland$enable_in_process"],
+        [xautoyes], [PKG_CHECK_MODULES([WAYLAND], [$WAYLAND_DEPS],
+                                       [enable_wayland=yes], [enable_wayland=no])],
+        [xyesyes], [PKG_CHECK_MODULES([WAYLAND], [$WAYLAND_DEPS])],
+        [xyes*], [AC_MSG_ERROR([--enable-wayland requires --enable-in-process])],
+        [enable_wayland=no])
+dnl should we make sure GDK has Wayland support? it seems unlikely it would
+dnl not, but still?
 
-if test "x$have_wayland" = "xyes"; then
-  AC_DEFINE(HAVE_WAYLAND, 1, [Have the Wayland development library])
-else
-  AC_DEFINE(HAVE_WAYLAND, 0, [Have the Wayland development library])
-fi
+AM_CONDITIONAL(IN_PROCESS, test "x$enable_in_process" = "xyes")
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [AC_DEFINE([IN_PROCESS], [1], [Enable if you want to build the panel applet in-process])])
+AM_CONDITIONAL(ENABLE_WAYLAND, [test "x$enable_wayland" = "xyes"])
+AS_IF([test "x$enable_wayland" = "xyes"],
+      [AC_DEFINE([ENABLE_WAYLAND], [1], [Enable if you want to build the panel applet in-process])])
 
-AC_SUBST(WAYLAND_CFLAGS)
-AC_SUBST(WAYLAND_LIBS)
-
-#=============================================================================================
-# Sanity check: must build either status icon or panel applet and wayland requires in-process
-#=============================================================================================
+#=============================================================================
+# Sanity check: must build either status icon or panel applet
+#=============================================================================
 
 if test "x$enable_statusicon" = "xno" && test "x$enable_panelapplet" = "xno"; then
 	AC_MSG_ERROR([must build either volume control status icon or volume control applet])
-fi
-
-if test "x$enable_in_process" = "xno" && test "x$have_wayland" = "xyes"; then
-	AC_MSG_ERROR([must build in-process to enable wayland])
-fi
-
-if test "x$enable_in_process" = "xyes" && test "x$have_wayland" = "xno"; then
-	AC_MSG_ERROR([in-process is only for wayland builds])
 fi
 
 AC_CONFIG_FILES([
@@ -232,20 +217,13 @@ if test "x$enable_statusicon" = "xno"; then
 else
 	echo "    Building status icon .......: yes"
 fi
+
 if test "x$enable_panelapplet" = "xno"; then
 	echo "    Building panel applet ......: no"
-else 
+else
 	echo "    Building panel applet ......: yes"
 fi
-if test "x$enable_in_process" = "xno"; then
-	echo "    Building in-process .......: no"
-else
-	echo "    Building in-process .......: yes"
-fi
-if test "x$enable_wayland" = "xno"; then
-	echo "    Building with wayland support .......: no"
-else
-	echo "    Building with wayland support .......: yes"
-fi
+echo "    Building in-process ......: $enable_in_process"
+echo "    Wayland support ..........: $enable_wayland"
 #get a newline in the terminal
 echo ""

--- a/configure.ac
+++ b/configure.ac
@@ -62,19 +62,6 @@ AC_SUBST(VOLUME_CONTROL_CFLAGS)
 AC_SUBST(VOLUME_CONTROL_LIBS)
 
 dnl=======================================================================
-dnl Check for wayland modules
-dnl=======================================================================
-
-PKG_CHECK_MODULES(wayland,
-                  gtk-layer-shell-0 >= $GTK_LAYER_SHELL_REQUIRED_VERSION
-                  gdk-wayland-3.0 >= $GDK_WAYLAND_REQUIRED_VERSION
-)
-
-AC_SUBST(VOLUME_CONTROL_CFLAGS)
-AC_SUBST(VOLUME_CONTROL_LIBS)
-
-
-dnl=======================================================================
 dnl GLib
 dnl=======================================================================
 
@@ -163,15 +150,13 @@ dnl - "yes" if explicitly enabled or if Wayland is explicitly enabled
 dnl - "auto" if nothing specific is requested, in which case, default back to "no"
 AS_IF([test "x$enable_in_process" != xyes], [enable_in_process=no])
 
-WAYLAND_DEPS="gtk-layer-shell-0 wayland-client gdk-wayland-3.0"
+WAYLAND_DEPS="gtk-layer-shell-0 >= $GTK_LAYER_SHELL_REQUIRED_VERSION wayland-client gdk-wayland-3.0 >= $GDK_WAYLAND_REQUIRED_VERSION"
 AS_CASE(["x$enable_wayland$enable_in_process"],
         [xautoyes], [PKG_CHECK_MODULES([WAYLAND], [$WAYLAND_DEPS],
                                        [enable_wayland=yes], [enable_wayland=no])],
         [xyesyes], [PKG_CHECK_MODULES([WAYLAND], [$WAYLAND_DEPS])],
         [xyes*], [AC_MSG_ERROR([--enable-wayland requires --enable-in-process])],
         [enable_wayland=no])
-dnl should we make sure GDK has Wayland support? it seems unlikely it would
-dnl not, but still?
 
 AM_CONDITIONAL(IN_PROCESS, test "x$enable_in_process" = "xyes")
 AS_IF([test "x$enable_in_process" = "xyes"],

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,8 @@ CANBERRA_REQUIRED_VERSION=0.13
 MATE_MIXER_REQUIRED_VERSION=1.10.0
 MATE_DESKTOP_REQUIRED_VERSION=1.17.0
 LIBPANEL4_REQUIRED=1.17.0
+GTK_LAYER_SHELL_REQUIRED_VERSION=0.6
+GDK_WAYLAND_REQUIRED_VERSION=3.22.0
 
 dnl=======================================================================
 dnl Check for the volume control modules
@@ -58,6 +60,19 @@ PKG_CHECK_MODULES(VOLUME_CONTROL,
 
 AC_SUBST(VOLUME_CONTROL_CFLAGS)
 AC_SUBST(VOLUME_CONTROL_LIBS)
+
+dnl=======================================================================
+dnl Check for wayland modules
+dnl=======================================================================
+
+PKG_CHECK_MODULES(wayland,
+                  gtk-layer-shell-0 >= $GTK_LAYER_SHELL_REQUIRED_VERSION
+                  gdk-wayland-3.0 >= $GDK_WAYLAND_REQUIRED_VERSION
+)
+
+AC_SUBST(VOLUME_CONTROL_CFLAGS)
+AC_SUBST(VOLUME_CONTROL_LIBS)
+
 
 dnl=======================================================================
 dnl GLib
@@ -148,7 +163,7 @@ dnl - "yes" if explicitly enabled or if Wayland is explicitly enabled
 dnl - "auto" if nothing specific is requested, in which case, default back to "no"
 AS_IF([test "x$enable_in_process" != xyes], [enable_in_process=no])
 
-WAYLAND_DEPS="gtk-layer-shell-0 wayland-client"
+WAYLAND_DEPS="gtk-layer-shell-0 wayland-client gdk-wayland-3.0"
 AS_CASE(["x$enable_wayland$enable_in_process"],
         [xautoyes], [PKG_CHECK_MODULES([WAYLAND], [$WAYLAND_DEPS],
                                        [enable_wayland=yes], [enable_wayland=no])],

--- a/configure.ac
+++ b/configure.ac
@@ -133,12 +133,16 @@ AM_CONDITIONAL(ENABLE_PANELAPPLET, test "x$enable_panelapplet" != "xno")
 dnl Whether to build the volume control applet in-process
 dnl --
 
-AC_ARG_ENABLE(in-process, [AS_HELP_STRING([--enable-in-process], [Enable in-process build of panel applet (default: yes, forced if wayland enabled)])],,[enable_in-process=yes] [in-process is forced if wayland support is enabled])
-if test "x$enable_panelapplet" = "xno"; then
-    AC_DEFINE(ENABLE_IN_PROCESS, 0, [Enable if you want to build the panel applet in-process])
-else
-    AC_DEFINE(ENABLE_IN_PROCESS, 1, [Enable if you want to build the panel applet in-process])
+AC_ARG_ENABLE(in-process, [AS_HELP_STRING([--enable-in-process], [Enable in-process build of panel applet (default: yes, required for wayland)])],,[enable_in-process=yes])
+
+AM_CONDITIONAL(IN_PROCESS, test "x$enable_in_process" != "xno")
+if test "x$enable_in_process" != "xno"; then
+    AC_DEFINE(IN_PROCESS, 1, [Enable if you want to build the panel applet in-process])
 fi
+
+AC_STRUCT_DIRENT_D_TYPE
+
+# $$enable_wayland will be set to "yes", "no" or "auto"
 
 AC_ARG_ENABLE(wayland,
               [AS_HELP_STRING([--enable-wayland],
@@ -157,22 +161,31 @@ if test "x$enable_wayland" != "xno"; then
     ])
 fi
 
-AM_CONDITIONAL(ENABLE_WAYLAND, test "x$enable_wayland" != "xno")
-if test "x$enable_wayland" = "xno"; then
-    AC_DEFINE(ENABLE_WAYLAND, 0, [Enable if you want to build the panel applet with wayland support])
+AM_CONDITIONAL(HAVE_WAYLAND, [test "x$have_wayland" = "xyes"])
+
+if test "x$have_wayland" = "xyes"; then
+  AC_DEFINE(HAVE_WAYLAND, 1, [Have the Wayland development library])
 else
-    AC_DEFINE(ENABLE_WAYLAND, 1, [Enable if you want to build the panel applet with wayland support])
-    AC_DEFINE(ENABLE_IN_PROCESS, 1, [in-process required for wayland support])
-    AC_SUBST(WAYLAND_CFLAGS)
-    AC_SUBST(WAYLAND_LIBS)
+  AC_DEFINE(HAVE_WAYLAND, 0, [Have the Wayland development library])
 fi
 
-#============================================================================
-# Sanity check: must build either status icon or panel applet
-#============================================================================
+AC_SUBST(WAYLAND_CFLAGS)
+AC_SUBST(WAYLAND_LIBS)
+
+#=============================================================================================
+# Sanity check: must build either status icon or panel applet and wayland requires in-process
+#=============================================================================================
 
 if test "x$enable_statusicon" = "xno" && test "x$enable_panelapplet" = "xno"; then
 	AC_MSG_ERROR([must build either volume control status icon or volume control applet])
+fi
+
+if test "x$enable_in_process" = "xno" && test "x$have_wayland" = "xyes"; then
+	AC_MSG_ERROR([must build in-process to enable wayland])
+fi
+
+if test "x$enable_in_process" = "xyes" && test "x$have_wayland" = "xno"; then
+	AC_MSG_ERROR([in-process is only for wayland builds])
 fi
 
 AC_CONFIG_FILES([
@@ -196,10 +209,6 @@ man/Makefile
 po/Makefile.in
 mate-volume-control/Makefile
 ])
-
-if test "x$have_wayland" = "xyes"; then
-  AC_DEFINE(HAVE_WAYLAND)
-fi
 
 AC_OUTPUT
 

--- a/mate-volume-control/Makefile.am
+++ b/mate-volume-control/Makefile.am
@@ -108,14 +108,13 @@ libmate_volume_control_applet_la_LIBADD = \
 	$(VOLUME_CONTROL_LIBS) \
 	$(NULL)
 
-if HAVE_WAYLAND
+if ENABLE_WAYLAND
 libmate_volume_control_applet_la_LIBADD += \
 	$(WAYLAND_LIBS)
 
 AM_CPPFLAGS += \
 	$(WAYLAND_CFLAGS)
-
-endif
+endif ENABLE_WAYLAND
 
 else
 libexec_PROGRAMS = mate-volume-control-applet

--- a/mate-volume-control/Makefile.am
+++ b/mate-volume-control/Makefile.am
@@ -91,6 +91,14 @@ libmate_volume_control_applet_la_LIBADD = \
 	$(VOLUME_CONTROL_LIBS) \
 	$(NULL)
 
+if ENABLE_WAYLAND
+libmate_volume_control_applet_la_LIBADD += \
+	$(WAYLAND_LIBS)
+
+AM_CPPFLAGS += \
+	$(WAYLAND_CFLAGS)
+endif
+
 endif
 
 mate_volume_control_LDADD = \

--- a/mate-volume-control/Makefile.am
+++ b/mate-volume-control/Makefile.am
@@ -1,4 +1,5 @@
 if ENABLE_STATUSICON
+
 bin_PROGRAMS = \
 	 mate-volume-control-status-icon \
 	 mate-volume-control \
@@ -21,16 +22,32 @@ AM_CPPFLAGS = \
 	$(NULL)
 
 if ENABLE_PANELAPPLET
-APPLET_LOCATION = $(libdir)/libmate-volume-control-applet.so
 appletsdir       = $(datadir)/mate-panel/applets
 applets_in_files = org.mate.applets.GvcApplet.mate-panel-applet.desktop.in
 applets_DATA     = $(applets_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
+if IN_PROCESS
+APPLET_LOCATION = $(libdir)/libmate-volume-control-applet.so
 mate_volume_control_applet_libdir= $(libdir)
 mate_volume_control_applet_lib_LTLIBRARIES=libmate-volume-control-applet.la
+IN_PROCESS = true
+
+else
+APPLET_LOCATION = $(libexecdir)/mate-volume-control-applet
+servicedir       = $(datadir)/dbus-1/services
+service_in_files = org.mate.panel.applet.GvcAppletFactory.service.in
+service_DATA     = $(service_in_files:.service.in=.service)
+IN_PROCESS = false
+
+org.mate.panel.applet.GvcAppletFactory.service: $(service_in_files)
+	$(AM_V_GEN)sed \
+		-e "s|\@LOCATION\@|$(APPLET_LOCATION)|" \
+		$< > $@
+endif
 
 $(applets_in_files): $(applets_in_files).in Makefile
 	$(AM_V_GEN)sed \
 		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@IN_PROCESS\@|$(IN_PROCESS)|" \
 		$< > $@
 
 $(applets_DATA): $(applets_in_files) Makefile
@@ -67,7 +84,7 @@ mate_volume_control_status_icon_CFLAGS = $(WARN_CFLAGS)
 endif
 
 if ENABLE_PANELAPPLET
-
+if IN_PROCESS
 libmate_volume_control_applet_la_LDFLAGS = \
 	-module -avoid-version \
 	$(WARN_LDFLAGS) \
@@ -91,14 +108,40 @@ libmate_volume_control_applet_la_LIBADD = \
 	$(VOLUME_CONTROL_LIBS) \
 	$(NULL)
 
-if ENABLE_WAYLAND
+if HAVE_WAYLAND
 libmate_volume_control_applet_la_LIBADD += \
 	$(WAYLAND_LIBS)
 
 AM_CPPFLAGS += \
 	$(WAYLAND_CFLAGS)
+
 endif
 
+else
+libexec_PROGRAMS = mate-volume-control-applet
+mate_volume_control_applet_LDADD = \
+	-lm \
+	libmatevolumecontrol.la \
+	$(VOLUME_CONTROL_LIBS) \
+	$(MATEDESKTOP_LIBS) \
+	$(NULL)
+
+mate_volume_control_applet_SOURCES = \
+	gvc-stream-applet-icon.h \
+	gvc-stream-applet-icon.c \
+	gvc-applet.h \
+	gvc-applet.c \
+	applet-main.c \
+	$(NULL)
+mate_volume_control_applet_CFLAGS = $(WARN_CFLAGS)
+
+mate_volume_control_applet_LDFLAGS = \
+	-module -avoid-version \
+	$(WARN_LDFLAGS) \
+	$(AM_LDFLAGS) \
+	$(NULL)
+
+endif
 endif
 
 mate_volume_control_LDADD = \
@@ -132,7 +175,6 @@ BUILT_SOURCES = \
 
 CLEANFILES = \
 	$(applets_in_files) \
-	$(BUILT_SOURCES) \
 	$(NULL)
 
 MAINTAINERCLEANFILES = \

--- a/mate-volume-control/Makefile.am
+++ b/mate-volume-control/Makefile.am
@@ -1,14 +1,13 @@
 if ENABLE_STATUSICON
-
 bin_PROGRAMS = \
 	 mate-volume-control-status-icon \
 	 mate-volume-control \
 	$(NULL)
-else
+else !ENABLE_STATUSICON
 bin_PROGRAMS = \
 	 mate-volume-control \
 	$(NULL)
-endif
+endif !ENABLE_STATUSICON
 
 AM_CPPFLAGS = \
 	$(WARN_CFLAGS) \
@@ -21,28 +20,29 @@ AM_CPPFLAGS = \
 	-I$(srcdir) \
 	$(NULL)
 
+applets_in_files = org.mate.applets.GvcApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.GvcAppletFactory.service.in
+
 if ENABLE_PANELAPPLET
 appletsdir       = $(datadir)/mate-panel/applets
-applets_in_files = org.mate.applets.GvcApplet.mate-panel-applet.desktop.in
 applets_DATA     = $(applets_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
+
 if IN_PROCESS
 APPLET_LOCATION = $(libdir)/libmate-volume-control-applet.so
 mate_volume_control_applet_libdir= $(libdir)
 mate_volume_control_applet_lib_LTLIBRARIES=libmate-volume-control-applet.la
 IN_PROCESS = true
-
-else
+else !IN_PROCESS
 APPLET_LOCATION = $(libexecdir)/mate-volume-control-applet
 servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.GvcAppletFactory.service.in
 service_DATA     = $(service_in_files:.service.in=.service)
 IN_PROCESS = false
 
-org.mate.panel.applet.GvcAppletFactory.service: $(service_in_files)
+$(service_in_files:.service.in=.service): $(service_in_files)
 	$(AM_V_GEN)sed \
 		-e "s|\@LOCATION\@|$(APPLET_LOCATION)|" \
 		$< > $@
-endif
+endif !IN_PROCESS
 
 $(applets_in_files): $(applets_in_files).in Makefile
 	$(AM_V_GEN)sed \
@@ -53,11 +53,7 @@ $(applets_in_files): $(applets_in_files).in Makefile
 $(applets_DATA): $(applets_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-EXTRA_DIST = \
-	$(applets_in_files).in \
-	$(service_in_files)
-
-endif
+endif ENABLE_PANELAPPLET
 
 noinst_LTLIBRARIES = libmatevolumecontrol.la
 libmatevolumecontrol_la_SOURCES = \
@@ -81,7 +77,7 @@ mate_volume_control_status_icon_SOURCES = \
 	$(NULL)
 
 mate_volume_control_status_icon_CFLAGS = $(WARN_CFLAGS)
-endif
+endif ENABLE_STATUSICON
 
 if ENABLE_PANELAPPLET
 if IN_PROCESS
@@ -116,7 +112,7 @@ AM_CPPFLAGS += \
 	$(WAYLAND_CFLAGS)
 endif ENABLE_WAYLAND
 
-else
+else !IN_PROCESS
 libexec_PROGRAMS = mate-volume-control-applet
 mate_volume_control_applet_LDADD = \
 	-lm \
@@ -140,8 +136,8 @@ mate_volume_control_applet_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	$(NULL)
 
-endif
-endif
+endif !IN_PROCESS
+endif ENABLE_PANELAPPLET
 
 mate_volume_control_LDADD = \
 	-lm \
@@ -179,5 +175,9 @@ CLEANFILES = \
 MAINTAINERCLEANFILES = \
 	*~ \
 	Makefile.in
+
+EXTRA_DIST = \
+	$(applets_in_files).in \
+	$(service_in_files)
 
 -include $(top_srcdir)/git.mk

--- a/mate-volume-control/applet-main.c
+++ b/mate-volume-control/applet-main.c
@@ -87,9 +87,17 @@ applet_factory (MatePanelApplet* applet, const char* iid, gpointer data)
         return retval;
 }
 
+#ifdef IN_PROCESS
 /* needed by mate-panel applet library */
 MATE_PANEL_APPLET_IN_PROCESS_FACTORY("GvcAppletFactory",
                                       PANEL_TYPE_APPLET,
                                       "Volume Control applet",
                                       applet_factory,
                                       NULL)
+#else
+MATE_PANEL_APPLET_OUT_PROCESS_FACTORY("GvcAppletFactory",
+                                      PANEL_TYPE_APPLET,
+                                      "Volume Control applet",
+                                      applet_factory,
+                                      NULL)
+#endif

--- a/mate-volume-control/gvc-applet.c
+++ b/mate-volume-control/gvc-applet.c
@@ -508,7 +508,7 @@ menu_activate_open_volume_control (GtkAction *action, GvcApplet *applet)
 gboolean
 gvc_applet_fill (GvcApplet *applet, MatePanelApplet* applet_widget)
 {
-#ifndef ENABLE_IN_PROCESS
+#ifndef IN_PROCESS
         GdkEventMask    event_mask;
         GdkWindow      *window;
 
@@ -545,7 +545,7 @@ gvc_applet_fill (GvcApplet *applet, MatePanelApplet* applet_widget)
         gtk_container_add (GTK_CONTAINER (applet->priv->applet), GTK_WIDGET (applet->priv->box));
         gtk_widget_show_all (GTK_WIDGET (applet->priv->applet));
 
-#ifndef ENABLE_IN_PROCESS
+#ifndef IN_PROCESS
         /* Enable 'scroll-event' signal to get through */
         window = gtk_widget_get_window (GTK_WIDGET (applet->priv->icon_input));
         event_mask = gdk_window_get_events (window);

--- a/mate-volume-control/gvc-applet.c
+++ b/mate-volume-control/gvc-applet.c
@@ -508,8 +508,14 @@ menu_activate_open_volume_control (GtkAction *action, GvcApplet *applet)
 gboolean
 gvc_applet_fill (GvcApplet *applet, MatePanelApplet* applet_widget)
 {
-        mate_panel_applet_set_flags (applet_widget, MATE_PANEL_APPLET_EXPAND_MINOR);
+#ifndef ENABLE_IN_PROCESS
+        GdkEventMask    event_mask;
+        GdkWindow      *window;
 
+        g_set_application_name (_("Volume Control Applet"));
+        gtk_window_set_default_icon_name (APPLET_ICON);
+        mate_panel_applet_set_flags (applet_widget, MATE_PANEL_APPLET_EXPAND_MINOR);
+#endif
         applet->priv->applet = applet_widget;
         /*FIXME: We haved to set this up BEFORE packing in icons. find a way to update this when the applet is moved that works*/
         switch (mate_panel_applet_get_orient (applet->priv->applet)) {
@@ -539,6 +545,16 @@ gvc_applet_fill (GvcApplet *applet, MatePanelApplet* applet_widget)
         gtk_container_add (GTK_CONTAINER (applet->priv->applet), GTK_WIDGET (applet->priv->box));
         gtk_widget_show_all (GTK_WIDGET (applet->priv->applet));
 
+#ifndef ENABLE_IN_PROCESS
+        /* Enable 'scroll-event' signal to get through */
+        window = gtk_widget_get_window (GTK_WIDGET (applet->priv->icon_input));
+        event_mask = gdk_window_get_events (window);
+        gdk_window_set_events (window, event_mask | GDK_SCROLL_MASK);
+
+        window = gtk_widget_get_window (GTK_WIDGET (applet->priv->icon_output));
+        event_mask = gdk_window_get_events (window);
+        gdk_window_set_events (window, event_mask | GDK_SCROLL_MASK);
+#endif
         /* Update icons on size/orientation changes*/
         g_object_connect (applet->priv->applet,
                          "signal::change_size", gvc_applet_set_size, applet,

--- a/mate-volume-control/gvc-stream-applet-icon.c
+++ b/mate-volume-control/gvc-stream-applet-icon.c
@@ -124,29 +124,46 @@ popup_dock (GvcStreamAppletIcon *icon, guint time)
             left = gtk_layer_get_anchor (GTK_WINDOW (toplevel), GTK_LAYER_SHELL_EDGE_LEFT);
             right = gtk_layer_get_anchor (GTK_WINDOW (toplevel), GTK_LAYER_SHELL_EDGE_RIGHT);
 
+            /*Set anchors to the edges (will hold to panel edge) and position along the panel
+             *Unset margins and anchors from any other position so as to avoid rendering issues
+             *when orientation changes as when the panel is moved
+             */
+
             if (top && left && right)
             {
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_BOTTOM, FALSE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_RIGHT, FALSE);
                 gtk_layer_set_margin (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, allocation.x);
+                gtk_layer_set_margin (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, 0);
             }
             if (bottom && left && right)
             {
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_BOTTOM, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, FALSE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_RIGHT, FALSE);
                 gtk_layer_set_margin (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, allocation.x);
+                gtk_layer_set_margin (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, 0);
             }
             if (left && bottom && top && !right)
             {
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, TRUE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_RIGHT, FALSE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_BOTTOM, FALSE);
                 gtk_layer_set_margin (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, allocation.y);
+                gtk_layer_set_margin (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, 0);
             }
             if (right && bottom && top && !left)
             {
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_RIGHT, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, TRUE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, FALSE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_BOTTOM, FALSE);
                 gtk_layer_set_margin (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, allocation.y);
+                gtk_layer_set_margin (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, 0);
             }
             gtk_widget_show_all (icon->priv->dock);
 

--- a/mate-volume-control/gvc-stream-applet-icon.c
+++ b/mate-volume-control/gvc-stream-applet-icon.c
@@ -24,11 +24,10 @@
 
 #include <glib.h>
 #include <glib/gi18n.h>
-#include <gdk/gdkx.h>
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
 
-#ifdef IN_PROCESS
+#if defined(ENABLE_WAYLAND) && defined(GDK_WINDOWING_WAYLAND)
 #include <gdk/gdkwayland.h>
 #include <gtk-layer-shell/gtk-layer-shell.h>
 #endif
@@ -99,56 +98,55 @@ popup_dock (GvcStreamAppletIcon *icon, guint time)
                 gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar), GTK_ORIENTATION_VERTICAL);
         }
 
-        monitor_num = gdk_display_get_monitor_at_point (gdk_screen_get_display (screen), allocation.x, allocation.y);
+        display = gdk_screen_get_display (screen);
+        monitor_num = gdk_display_get_monitor_at_point (display, allocation.x, allocation.y);
         gdk_monitor_get_geometry (monitor_num, &monitor);
 
         gtk_container_foreach (GTK_CONTAINER (icon->priv->dock), (GtkCallback) gtk_widget_show_all, NULL);
         gtk_widget_get_preferred_size (icon->priv->dock, &dock_req, NULL);
 
-        display = gdk_screen_get_display (gdk_screen_get_default());
-#ifdef IN_PROCESS
-        if  (GDK_IS_WAYLAND_DISPLAY (display))
+#if defined(ENABLE_WAYLAND) && defined(GDK_WINDOWING_WAYLAND)
+        if (GDK_IS_WAYLAND_DISPLAY (display))
         {
             gboolean top, bottom, left, right;
             GtkWidget *toplevel;
             toplevel = gtk_widget_get_toplevel (GTK_WIDGET (icon));
-        
-            if (!gtk_layer_is_layer_window(GTK_WINDOW (icon->priv->dock)))
+
+            if (!gtk_layer_is_layer_window (GTK_WINDOW (icon->priv->dock)))
             {
                 gtk_layer_init_for_window (GTK_WINDOW (icon->priv->dock));
                 gtk_layer_set_layer (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_LAYER_BOTTOM);
                 gtk_layer_set_keyboard_mode (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND);
             }
-         
-            top = gtk_layer_get_anchor(GTK_WINDOW(toplevel), GTK_LAYER_SHELL_EDGE_TOP);  
-            bottom = gtk_layer_get_anchor(GTK_WINDOW(toplevel), GTK_LAYER_SHELL_EDGE_BOTTOM);  
-            left = gtk_layer_get_anchor(GTK_WINDOW(toplevel), GTK_LAYER_SHELL_EDGE_LEFT);
-            right = gtk_layer_get_anchor(GTK_WINDOW(toplevel), GTK_LAYER_SHELL_EDGE_RIGHT);  
+
+            top = gtk_layer_get_anchor (GTK_WINDOW (toplevel), GTK_LAYER_SHELL_EDGE_TOP);
+            bottom = gtk_layer_get_anchor (GTK_WINDOW (toplevel), GTK_LAYER_SHELL_EDGE_BOTTOM);
+            left = gtk_layer_get_anchor (GTK_WINDOW (toplevel), GTK_LAYER_SHELL_EDGE_LEFT);
+            right = gtk_layer_get_anchor (GTK_WINDOW (toplevel), GTK_LAYER_SHELL_EDGE_RIGHT);
 
             if (top && left && right)
             {
-                gtk_layer_set_anchor(GTK_WINDOW (icon->priv->dock) ,GTK_LAYER_SHELL_EDGE_TOP, TRUE);
-                gtk_layer_set_anchor(GTK_WINDOW (icon->priv->dock) ,GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, TRUE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
                 gtk_layer_set_margin (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, allocation.x);
-
             }
             if (bottom && left && right)
             {
-                gtk_layer_set_anchor(GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_BOTTOM, TRUE);
-                gtk_layer_set_anchor(GTK_WINDOW (icon->priv->dock) ,GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
-                gtk_layer_set_margin(GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, allocation.x);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_BOTTOM, TRUE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
+                gtk_layer_set_margin (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, allocation.x);
             }
             if (left && bottom && top && !right)
             {
-                gtk_layer_set_anchor(GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
-                gtk_layer_set_anchor(GTK_WINDOW (icon->priv->dock) ,GTK_LAYER_SHELL_EDGE_TOP, TRUE);
-                gtk_layer_set_margin(GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, allocation.y);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, TRUE);
+                gtk_layer_set_margin (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, allocation.y);
             }
             if (right && bottom && top && !left)
             {
-                gtk_layer_set_anchor(GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_RIGHT, TRUE);
-                gtk_layer_set_anchor(GTK_WINDOW (icon->priv->dock) ,GTK_LAYER_SHELL_EDGE_TOP, TRUE);
-                gtk_layer_set_margin(GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, allocation.y);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_RIGHT, TRUE);
+                gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, TRUE);
+                gtk_layer_set_margin (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, allocation.y);
             }
             gtk_widget_show_all (icon->priv->dock);
 
@@ -158,8 +156,8 @@ popup_dock (GvcStreamAppletIcon *icon, guint time)
 
             return TRUE;
         }
-        else
-#endif
+#endif /* wayland support */
+
         if (icon->priv->orient == MATE_PANEL_APPLET_ORIENT_LEFT || icon->priv->orient == MATE_PANEL_APPLET_ORIENT_RIGHT) {
                 if (allocation.x + allocation.width + dock_req.width <= monitor.x + monitor.width)
                         x = allocation.x + allocation.width;

--- a/mate-volume-control/org.mate.applets.GvcApplet.mate-panel-applet.desktop.in.in
+++ b/mate-volume-control/org.mate.applets.GvcApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,6 @@
 [Applet Factory]
 Id=GvcAppletFactory
-InProcess=true
+InProcess=@IN_PROCESS@
 Location=@APPLET_LOCATION@
 Name=Volume Control Factory
 Description=Volume Control Factory

--- a/mate-volume-control/org.mate.panel.applet.GvcAppletFactory.service
+++ b/mate-volume-control/org.mate.panel.applet.GvcAppletFactory.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.mate.panel.applet.GvcAppletFactory
+Exec=/usr/libexec/mate-volume-control-applet
+

--- a/mate-volume-control/org.mate.panel.applet.GvcAppletFactory.service.in
+++ b/mate-volume-control/org.mate.panel.applet.GvcAppletFactory.service.in
@@ -1,4 +1,3 @@
 [D-BUS Service]
 Name=org.mate.panel.applet.GvcAppletFactory
-Exec=/usr/libexec/mate-volume-control-applet
-
+Exec=@LOCATION@


### PR DESCRIPTION
Position the slider correctly in wayland (all four panel orientations tested) and allow passing --disable-wayland and --disable-in-process together for non-wayland, out of process builds