### PR TITLE
in-process: enable scrolling on icon as in out of process builds

### DIFF
--- a/mate-volume-control/gvc-applet.c
+++ b/mate-volume-control/gvc-applet.c
@@ -509,9 +509,6 @@ gboolean
 gvc_applet_fill (GvcApplet *applet, MatePanelApplet* applet_widget)
 {
 #ifndef IN_PROCESS
-        GdkEventMask    event_mask;
-        GdkWindow      *window;
-
         g_set_application_name (_("Volume Control Applet"));
         gtk_window_set_default_icon_name (APPLET_ICON);
         mate_panel_applet_set_flags (applet_widget, MATE_PANEL_APPLET_EXPAND_MINOR);
@@ -545,20 +542,10 @@ gvc_applet_fill (GvcApplet *applet, MatePanelApplet* applet_widget)
         gtk_container_add (GTK_CONTAINER (applet->priv->applet), GTK_WIDGET (applet->priv->box));
         gtk_widget_show_all (GTK_WIDGET (applet->priv->applet));
 
-#ifdef IN_PROCESS
-         /* Enable 'scroll-event' signal to be received w/o an applet GtkPlug window */
+        /* Enable 'scroll-event' signal to be received  */
         gtk_widget_add_events (GTK_WIDGET(applet->priv->icon_input), GDK_SCROLL_MASK);
         gtk_widget_add_events (GTK_WIDGET(applet->priv->icon_output), GDK_SCROLL_MASK);
-#else
-        /* Enable 'scroll-event' signal to get through */
-        window = gtk_widget_get_window (GTK_WIDGET (applet->priv->icon_input));
-        event_mask = gdk_window_get_events (window);
-        gdk_window_set_events (window, event_mask | GDK_SCROLL_MASK);
 
-        window = gtk_widget_get_window (GTK_WIDGET (applet->priv->icon_output));
-        event_mask = gdk_window_get_events (window);
-        gdk_window_set_events (window, event_mask | GDK_SCROLL_MASK);
-#endif
         /* Update icons on size/orientation changes*/
         g_object_connect (applet->priv->applet,
                          "signal::change_size", gvc_applet_set_size, applet,

--- a/mate-volume-control/gvc-applet.c
+++ b/mate-volume-control/gvc-applet.c
@@ -545,7 +545,11 @@ gvc_applet_fill (GvcApplet *applet, MatePanelApplet* applet_widget)
         gtk_container_add (GTK_CONTAINER (applet->priv->applet), GTK_WIDGET (applet->priv->box));
         gtk_widget_show_all (GTK_WIDGET (applet->priv->applet));
 
-#ifndef IN_PROCESS
+#ifdef IN_PROCESS
+         /* Enable 'scroll-event' signal to be received w/o an applet GtkPlug window */
+        gtk_widget_add_events (GTK_WIDGET(applet->priv->icon_input), GDK_SCROLL_MASK);
+        gtk_widget_add_events (GTK_WIDGET(applet->priv->icon_output), GDK_SCROLL_MASK);
+#else
         /* Enable 'scroll-event' signal to get through */
         window = gtk_widget_get_window (GTK_WIDGET (applet->priv->icon_input));
         event_mask = gdk_window_get_events (window);


### PR DESCRIPTION
The method used out of process to enable scrolling on the icon without clicking on it to raise and lower volume does not work in-process, so set the event mask to enable scrolling directly when building in-process