### PR TITLE
Wayland: fix slider rendering underneath fullscreen windows

### DIFF
--- a/mate-volume-control/gvc-stream-applet-icon.c
+++ b/mate-volume-control/gvc-stream-applet-icon.c
@@ -115,7 +115,7 @@ popup_dock (GvcStreamAppletIcon *icon, guint time)
             if (!gtk_layer_is_layer_window (GTK_WINDOW (icon->priv->dock)))
             {
                 gtk_layer_init_for_window (GTK_WINDOW (icon->priv->dock));
-                gtk_layer_set_layer (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_LAYER_BOTTOM);
+                gtk_layer_set_layer (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_LAYER_TOP);
                 gtk_layer_set_keyboard_mode (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND);
             }
 


### PR DESCRIPTION
*Set slider as the top layer not the bottom using gtk-layer-shell
*Fix https://github.com/mate-desktop/mate-media/issues/198