### PR TITLE
applet: Do not override the process' text domain

### DIFF
--- a/mate-volume-control/applet-main.c
+++ b/mate-volume-control/applet-main.c
@@ -24,7 +24,7 @@
 #include "config.h"
 
 #include <glib.h>
-#include <glib/gi18n.h>
+#include <glib/gi18n-lib.h>
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
@@ -41,10 +41,6 @@ applet_main (MatePanelApplet* applet_widget)
         GError       *error = NULL;
         GvcApplet    *applet;
         GApplication *app = NULL;
-
-        bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
-        bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
-        textdomain (GETTEXT_PACKAGE);
 
         app = g_application_new (GVC_APPLET_DBUS_NAME, G_APPLICATION_FLAGS_NONE);
 

--- a/mate-volume-control/gvc-applet.c
+++ b/mate-volume-control/gvc-applet.c
@@ -25,7 +25,7 @@
 
 #include <string.h>
 #include <glib.h>
-#include <glib/gi18n.h>
+#include <glib/gi18n-lib.h>
 #include <glib-object.h>
 #include <gtk/gtk.h>
 

--- a/mate-volume-control/gvc-channel-bar.c
+++ b/mate-volume-control/gvc-channel-bar.c
@@ -25,7 +25,7 @@
 #include <sys/param.h>
 
 #include <glib.h>
-#include <glib/gi18n.h>
+#include <glib/gi18n-lib.h>
 #include <glib-object.h>
 #include <gtk/gtk.h>
 

--- a/mate-volume-control/gvc-stream-applet-icon.c
+++ b/mate-volume-control/gvc-stream-applet-icon.c
@@ -23,7 +23,7 @@
 #include <config.h>
 
 #include <glib.h>
-#include <glib/gi18n.h>
+#include <glib/gi18n-lib.h>
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
 


### PR DESCRIPTION
When loaded as in-process applet, we must not call `textdomain()` or we will override mate-panel's text domain.  Instead, properly use gi18n-lib.h header that provides the same API but uses the compile-time `GETTEXT_PACKAGE` value for each call.

Fixes #203.