### PR TITLE
add meson build support

### DIFF
--- a/build-aux/meson_post_install.sh
+++ b/build-aux/meson_post_install.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+if [ -z $MESON_INSTALL_PREFIX ]; then
+    echo 'This is meant to be ran from Meson only!'
+    exit 1
+fi
+
+if [ -z $DESTDIR ]; then
+    echo 'Compiling GSchema'
+    glib-compile-schemas "$MESON_INSTALL_PREFIX/share/glib-2.0/schemas"
+    echo 'Updating icon cache'
+    gtk-update-icon-cache -qtf "$MESON_INSTALL_PREFIX/share/icons/hicolor"
+    echo 'Updating desktop database'
+    update-desktop-database -q "$MESON_INSTALL_PREFIX/share/applications"
+fi

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -1,0 +1,67 @@
+status_icons = [
+  ['16x16', 'audio-input-microphone-high.png', 'audio-input-microphone-low.png', 'audio-input-microphone-medium.png', 'audio-input-microphone-muted.png'],
+  ['22x22', 'audio-input-microphone-high.png', 'audio-input-microphone-low.png', 'audio-input-microphone-medium.png', 'audio-input-microphone-muted.png'],
+  ['24x24', 'audio-input-microphone-high.png', 'audio-input-microphone-low.png', 'audio-input-microphone-medium.png', 'audio-input-microphone-muted.png'],
+  ['32x32', 'audio-input-microphone-high.png', 'audio-input-microphone-low.png', 'audio-input-microphone-medium.png', 'audio-input-microphone-muted.png'],
+]
+
+foreach icon: status_icons
+  install_data(
+    join_paths(icon[0], 'status', icon[1]),
+    install_dir: join_paths(mm_iconsdir, 'hicolor', icon[0], 'status')
+  )
+  install_data(
+    join_paths(icon[0], 'status', icon[2]),
+    install_dir: join_paths(mm_iconsdir, 'hicolor', icon[0], 'status')
+  )
+  install_data(
+    join_paths(icon[0], 'status', icon[3]),
+    install_dir: join_paths(mm_iconsdir, 'hicolor', icon[0], 'status')
+  )
+  install_data(
+    join_paths(icon[0], 'status', icon[4]),
+    install_dir: join_paths(mm_iconsdir, 'hicolor', icon[0], 'status')
+  )
+endforeach
+
+scalable_icons = [
+  'audio-input-microphone-high.svg',
+  'audio-input-microphone-low.svg',
+  'audio-input-microphone-medium.svg',
+  'audio-input-microphone-muted.svg'
+]
+
+foreach icon: scalable_icons
+    install_data(
+    join_paths('scalable', 'status', icon),
+    install_dir: join_paths(mm_iconsdir, 'hicolor', 'scalable', 'status')
+  )
+endforeach
+
+devices_icons = [
+  'audio-speaker-center-back.svg',
+  'audio-speaker-center-back-testing.svg',
+  'audio-speaker-center.svg',
+  'audio-speaker-center-testing.svg',
+  'audio-speaker-left-back.svg',
+  'audio-speaker-left-back-testing.svg',
+  'audio-speaker-left-side.svg',
+  'audio-speaker-left-side-testing.svg',
+  'audio-speaker-left.svg',
+  'audio-speaker-left-testing.svg',
+  'audio-speaker-right-back.svg',
+  'audio-speaker-right-back-testing.svg',
+  'audio-speaker-right-side.svg',
+  'audio-speaker-right-side-testing.svg',
+  'audio-speaker-right.svg',
+  'audio-speaker-right-testing.svg',
+  'audio-subwoofer.svg',
+  'audio-subwoofer-testing.svg',
+]
+
+foreach icon: devices_icons
+    install_data(
+    join_paths('scalable', 'devices', icon),
+    install_dir: join_paths(mm_iconsdir, 'hicolor', '48x48', 'devices')
+  )
+endforeach

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,33 @@
+po_dir = join_paths(meson.source_root(), 'po')
+its_dir = join_paths(meson.source_root())
+subdir('icons')
+subdir('sounds')
+# .desktop file
+
+desktop_data = configuration_data()
+desktop_data.set('VERSION', meson.project_version())
+desktop_in_file = configure_file(
+  input : 'mate-volume-control.desktop.in.in',
+  output : 'mate-volume-control.desktop.in',
+  configuration : desktop_data
+)
+
+i18n.merge_file(
+  input : desktop_in_file,
+  output : 'mate-volume-control.desktop',
+  type : 'desktop',
+  po_dir : po_dir,
+  install : true,
+  install_dir : join_paths(mm_datadir, 'applications')
+)
+
+desktop = 'mate-volume-control-status-icon.desktop'
+
+i18n.merge_file(
+  type: 'desktop',
+  input: desktop + '.in',
+  output: desktop,
+  po_dir: po_dir,
+  install: true,
+  install_dir: join_paths(get_option('sysconfdir'), 'xdg', 'autostart')
+)

--- a/data/sounds/meson.build
+++ b/data/sounds/meson.build
@@ -1,0 +1,29 @@
+xml_data = configuration_data()
+xml_data.set('datadir', mm_datadir)
+xml_in_file = configure_file(
+  input : 'mate-sounds-default.xml.in.in',
+  output : 'mate-sounds-default.xml.in',
+  configuration : xml_data
+)
+
+i18n.merge_file(
+  input: xml_in_file,
+  output: 'mate-sounds-default.xml',
+  po_dir: po_dir,
+  data_dirs: its_dir,
+  install: true,
+  install_dir: join_paths(mm_pkgdatadir, 'sounds')
+)
+
+oggs = [
+  'bark.ogg',
+  'drip.ogg',
+  'glass.ogg',
+  'sonar.ogg'
+]
+foreach ogg: oggs
+    install_data(
+    ogg,
+    install_dir: join_paths(mm_datadir, 'sounds', 'mate', 'default', 'alerts')
+  )
+endforeach

--- a/man/meson.build
+++ b/man/meson.build
@@ -1,0 +1,8 @@
+man1_dir = join_paths(mm_mandir, 'man1')
+
+install_data('mate-volume-control-status-icon.1',
+  install_dir : man1_dir
+)
+install_data('mate-volume-control.1',
+  install_dir : man1_dir
+)

--- a/mate-volume-control/meson.build
+++ b/mate-volume-control/meson.build
@@ -1,0 +1,154 @@
+po_dir = join_paths(meson.source_root(), 'po')
+
+cflags = [
+  '-DMATELOCALEDIR="@0@"'.format(mm_localedir),
+  '-DLOCALE_DIR="@0@"'.format(mm_localedir),
+  '-DICON_DATA_DIR="@0@"'.format(mm_iconsdir),
+  '-DSOUND_SET_DIR="@0@"'.format(mm_soundsdir),
+  '-DI_KNOW_THE_DEVICEKIT_POWER_API_IS_SUBJECT_TO_CHANGE',
+]
+deps = [
+  glib,
+  gtk,
+  matemixer
+]
+if enable_wayland == 'yes'
+  deps += [gdkwayland, waylandclient, gls]
+endif
+
+libmvc_static = static_library(
+  'libmatevolumecontrol',
+  sources: 'gvc-channel-bar.c',
+  include_directories: config_inc,
+  dependencies: deps,
+  c_args: cflags,
+  install: false,
+)
+
+if enable_applet
+  desktop_data = configuration_data()
+  
+  if enable_process
+    desktop_data.set('APPLET_LOCATION', join_paths(mm_libdir, 'libmate-volume-control-applet.so'))
+    desktop_data.set('IN_PROCESS', 'true')
+    
+    libmvca_shared = library(
+      'libmate-volume-control-applet',
+      sources: [
+        'gvc-stream-applet-icon.c',
+        'gvc-applet.c',
+        'applet-main.c'
+      ],
+      include_directories: config_inc,
+      dependencies: [
+        deps,
+        matepanel,
+        md,
+        canberra,
+        libm
+      ],
+      link_with :libmvc_static,
+      c_args: cflags,
+      install: true,
+      install_dir : mm_libdir, 
+    )
+
+  else
+    desktop_data.set('APPLET_LOCATION', join_paths(mm_execdir, 'mate-volume-control-applet'))
+    desktop_data.set('IN_PROCESS', 'flase')
+    
+    service_data = configuration_data()
+    service_data.set('LOCATION', join_paths(mm_execdir, 'mate-volume-control-applet'))
+    configure_file(
+      input : 'org.mate.panel.applet.GvcAppletFactory.service.in',
+      output : 'org.mate.panel.applet.GvcAppletFactory.service',
+      configuration : service_data,
+      install : true,
+      install_dir : join_paths(mm_datadir, 'dbus-1/services')
+    )
+    executable(
+      'mate-volume-control-applet',
+      sources : [
+        'gvc-stream-applet-icon.c',
+        'gvc-applet.c',
+        'applet-main.c'
+      ],
+      include_directories: config_inc,
+      dependencies : [
+        deps,
+        matepanel,
+        md,
+        canberra,
+        libm
+      ],
+      link_with :libmvc_static,
+      c_args : cflags,
+      install : true,
+      install_dir : mm_execdir
+    )
+  endif
+
+  desktop_in_file = configure_file(
+    input : 'org.mate.applets.GvcApplet.mate-panel-applet.desktop.in.in',
+    output : 'org.mate.applets.GvcApplet.mate-panel-applet.desktop.in',
+    configuration : desktop_data
+  )
+  i18n.merge_file(
+    input : desktop_in_file,
+    output : 'org.mate.applets.GvcApplet.mate-panel-applet.desktop',
+    type : 'desktop',
+    po_dir : po_dir,
+    install : true,
+    install_dir : join_paths(mm_datadir, 'mate-panel', 'applets')
+  )
+
+endif
+
+if enable_statusicon
+  executable(
+    'mate-volume-control-status-icon',
+    sources : [
+      'gvc-stream-status-icon.c',
+      'gvc-status-icon.c',
+      'status-icon-main.c'
+    ],
+    include_directories: config_inc,
+    dependencies : [
+      deps,
+      md,
+      canberra,
+      libm
+    ],
+    link_with :libmvc_static,
+    c_args : cflags,
+    install : true,
+    install_dir : get_option('bindir')
+)
+endif
+executable(
+  'mate-volume-control',
+  sources : [
+    'gvc-balance-bar.c',
+    'gvc-level-bar.c',
+    'gvc-combo-box.c',
+    'gvc-sound-theme-chooser.c',
+    'gvc-speaker-test.c',
+    'gvc-utils.c',
+    'sound-theme-file-utils.c',
+    'gvc-mixer-dialog.c',
+    'dialog-main.c'
+  ],
+  include_directories : config_inc,
+  dependencies : [
+    libm,
+    canberra,
+    md,
+    libxml,
+    deps
+  ],
+  link_with :libmvc_static,
+  c_args : cflags,
+  install : true,
+  install_dir : get_option('bindir')
+)
+

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,170 @@
+project('mate-media', 'c',
+  version : '1.27.0',
+  default_options : ['warning_level=1'],
+  meson_version : '>=0.50.0'
+)
+
+conf = configuration_data()
+
+prefix = get_option('prefix')
+mm_execdir = join_paths(prefix, get_option('libexecdir'))
+mm_libdir = join_paths(prefix, get_option('libdir'))
+mm_datadir = join_paths(prefix, get_option('datadir'))
+mm_localedir = join_paths(prefix, get_option('localedir'))
+mm_bindir = join_paths(prefix, get_option('bindir'))
+mm_sbindir = join_paths(prefix, get_option('sbindir'))
+mm_mandir = join_paths(prefix, get_option('mandir'))
+mm_desktopdir =  join_paths(mm_datadir, 'applications')
+mm_pkgdatadir =  join_paths(mm_datadir, meson.project_name())
+mm_iconsdir =  join_paths(mm_pkgdatadir, 'icons')
+mm_soundsdir =  join_paths(mm_pkgdatadir, 'sounds')
+
+# get suported warning flags
+test_args = [
+  '-Waggregate-return',
+  '-Warray-bounds',
+  '-Wcast-align',
+  '-Wclobbered',
+  '-Wdeclaration-after-statement',
+  '-Wempty-body',
+  '-Wextra',
+  '-Wformat=2',
+  '-Wformat-nonliteral',
+  '-Wformat-security',
+  '-Wformat-signedness',
+  '-Wignored-qualifiers',
+  '-Wimplicit-function-declaration',
+  '-Winit-self',
+  '-Winline',
+  '-Wmissing-declarations',
+  '-Wmissing-format-attribute',
+  '-Wmissing-include-dirs',
+  '-Wmissing-noreturn',
+  '-Wmissing-parameter-type',
+  '-Wmissing-prototypes',
+  '-Wnested-externs',
+  '-Wno-discarded-qualifiers',
+  '-Wno-missing-field-initializers',
+  '-Wno-strict-aliasing',
+  '-Wno-suggest-attribute=format',
+  '-Wno-unused-parameter',
+  '-Wold-style-definition',
+  '-Woverride-init',
+  '-Wpacked',
+  '-Wpointer-arith',
+  '-Wredundant-decls',
+  '-Wreturn-type',
+  '-Wshadow',
+  '-Wsign-compare',
+  '-Wstrict-aliasing',
+  '-Wstrict-prototypes',
+  '-Wswitch-default',
+  '-Wtype-limits',
+  '-Wundef',
+  '-Wuninitialized',
+  '-Wunused-but-set-variable',
+  '-Wwrite-strings'
+]
+cc = meson.get_compiler('c')
+foreach arg: test_args
+  if cc.has_argument(arg)
+    add_project_arguments(arg, language : 'c')
+  endif
+endforeach
+
+common_flags = [
+  '-DHAVE_CONFIG_H',
+]
+
+add_project_arguments(common_flags, language: 'c')
+# enable full RELRO where possible
+# FIXME: until https://github.com/mesonbuild/meson/issues/1140 is fixed
+test_link_args = [
+  '-Wl,-z,relro',
+  '-Wl,-z,now',
+]
+foreach arg: test_link_args
+  if cc.has_link_argument(arg)
+    add_project_link_arguments(arg, language : 'c')
+  endif
+endforeach
+
+enable_statusicon = get_option('statusicon')
+enable_applet = get_option('panelapplet')
+enable_wayland = get_option('wayland')
+enable_process = get_option('in-process')
+
+if enable_wayland == 'auto'
+  if enable_process
+    enable_wayland = 'yes'
+  else
+    enable_wayland = 'no'
+  endif
+elif enable_wayland == 'yes'
+  if not enable_process
+    error ('enable-wayland is yes requires enable-in-process is true')
+  endif
+endif
+
+gtk = dependency('gtk+-3.0', version : '>= 3.22.0')
+glib = dependency('glib-2.0', version : '>= 2.50.0')
+gdk = dependency('gdk-3.0', version : '>= 3.22.0')
+matemixer = dependency('libmatemixer', version : '>= 1.10.0')
+canberra = dependency('libcanberra-gtk3', version : '>= 0.13')
+md = dependency('mate-desktop-2.0', version : '>= 1.27.1')
+matepanel = dependency('libmatepanelapplet-4.0', version : '>= 1.17.0',required: enable_applet)
+libxml = dependency('libxml-2.0')
+libm = cc.find_library('m', required: false)
+
+if enable_wayland == 'yes'
+  gls = dependency('gtk-layer-shell-0', version : '>= 0.6')
+  waylandclient = dependency('wayland-client')
+  gdkwayland = dependency('gdk-wayland-3.0', version : '>= 3.22.0')
+  conf.set('ENABLE_WAYLAND', 1)
+endif
+if enable_process
+  conf.set('IN_PROCESS', 1)
+endif
+if enable_statusicon
+  conf.set('ENABLE_STATUSICON', 1)
+endif
+if enable_applet
+  conf.set('ENABLE_PANELAPPLET', 1)
+endif
+
+gnome = import('gnome')
+i18n = import('i18n')
+
+conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+conf.set_quoted('LOCALEDIR', mm_localedir)
+conf.set_quoted('DATADIR', mm_datadir)
+
+conf.set_quoted('PACKAGE_URL', 'https://mate-desktop.org')
+conf.set_quoted('VERSION', meson.project_version())
+conf.set_quoted('PACKAGE_VERSION', meson.project_version())
+
+configure_file(
+  output : 'config.h',
+  configuration : conf
+)
+config_inc = include_directories('.')
+
+subdir('man')
+subdir('mate-volume-control')
+subdir('po')
+subdir('data')
+
+summary = [
+  'configuration summary:',
+  '',
+  '                         project: @0@ @1@'.format(meson.project_name(), meson.project_version()),
+  '                          prefix: @0@'.format(prefix),
+  '            Building status icon: @0@'.format(enable_statusicon),
+  '           Building panel applet: @0@'.format(enable_applet),
+  '             Building in-process: @0@'.format(enable_process),
+  '                 Wayland support: @0@'.format(enable_wayland),
+  ''
+]
+message('\n'.join(summary))
+
+meson.add_install_script('build-aux/meson_post_install.sh')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('statusicon', type : 'boolean', value : true, description : 'enable tests')
+option('panelapplet', type : 'boolean', value : true, description : 'gnome-keyring support')
+option('wayland', type : 'string', value : 'auto', description : 'wayland enabled')
+option('in-process', type : 'boolean', value : false, description : 'in-process enabled')

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,0 +1,6 @@
+i18n.gettext(meson.project_name(),
+  preset : 'glib',
+  args: [
+    '--default-domain=' + meson.project_name()
+  ]
+)


### PR DESCRIPTION
## test meson
```
meson setup _build --prefix=/usr -Din-process=true -Ddefault_library=both

ninja -C _build

DESTDIR=/tmp/meson_dir meson install -C _build
```
## test make
```
 ./autogen.sh --prefix=/usr --enable-in-process=yes

make

make install DESTDIR=/tmp/make_dir
```
## Compare Build Results
```
[test@localhost mate-power-manager]$ find /tmp/make_dir/ | wc -l
489
[test@localhost mate-power-manager]$ find /tmp/meson_dir/ | wc -l
488
```
```meson``` does not provide ```libmate-volume-control-applet.la```, so the total number is one less, which is not a problem