### PR TITLE
Fix various instance checks

### DIFF
--- a/mate-volume-control/gvc-balance-bar.c
+++ b/mate-volume-control/gvc-balance-bar.c
@@ -236,7 +236,7 @@ find_stream_lfe_channel (MateMixerStreamControl *control)
 static void
 gvc_balance_bar_set_control (GvcBalanceBar *bar, MateMixerStreamControl *control)
 {
-        g_return_if_fail (GVC_BALANCE_BAR (bar));
+        g_return_if_fail (GVC_IS_BALANCE_BAR (bar));
         g_return_if_fail (MATE_MIXER_IS_STREAM_CONTROL (control));
 
         if (bar->priv->control != NULL) {

--- a/mate-volume-control/gvc-level-bar.c
+++ b/mate-volume-control/gvc-level-bar.c
@@ -295,7 +295,7 @@ void
 gvc_level_bar_set_peak_adjustment (GvcLevelBar   *bar,
                                    GtkAdjustment *adjustment)
 {
-        g_return_if_fail (GVC_LEVEL_BAR (bar));
+        g_return_if_fail (GVC_IS_LEVEL_BAR (bar));
         g_return_if_fail (GTK_IS_ADJUSTMENT (adjustment));
 
         if (bar->priv->peak_adjustment != NULL) {
@@ -321,7 +321,7 @@ void
 gvc_level_bar_set_rms_adjustment (GvcLevelBar   *bar,
                                   GtkAdjustment *adjustment)
 {
-        g_return_if_fail (GVC_LEVEL_BAR (bar));
+        g_return_if_fail (GVC_IS_LEVEL_BAR (bar));
         g_return_if_fail (GTK_IS_ADJUSTMENT (adjustment));
 
         if (bar->priv->rms_adjustment != NULL) {

--- a/mate-volume-control/gvc-stream-applet-icon.c
+++ b/mate-volume-control/gvc-stream-applet-icon.c
@@ -575,7 +575,7 @@ void
 gvc_stream_applet_icon_set_display_name (GvcStreamAppletIcon *icon,
                                          const gchar         *name)
 {
-        g_return_if_fail (GVC_STREAM_APPLET_ICON (icon));
+        g_return_if_fail (GVC_IS_STREAM_APPLET_ICON (icon));
 
         g_free (icon->priv->display_name);
 
@@ -589,7 +589,7 @@ void
 gvc_stream_applet_icon_set_control (GvcStreamAppletIcon    *icon,
                                     MateMixerStreamControl *control)
 {
-        g_return_if_fail (GVC_STREAM_APPLET_ICON (icon));
+        g_return_if_fail (GVC_IS_STREAM_APPLET_ICON (icon));
 
         if (icon->priv->control == control)
                 return;

--- a/mate-volume-control/gvc-stream-status-icon.c
+++ b/mate-volume-control/gvc-stream-status-icon.c
@@ -513,7 +513,7 @@ void
 gvc_stream_status_icon_set_display_name (GvcStreamStatusIcon *icon,
                                          const gchar         *name)
 {
-        g_return_if_fail (GVC_STREAM_STATUS_ICON (icon));
+        g_return_if_fail (GVC_IS_STREAM_STATUS_ICON (icon));
 
         g_free (icon->priv->display_name);
 
@@ -527,7 +527,7 @@ void
 gvc_stream_status_icon_set_control (GvcStreamStatusIcon    *icon,
                                     MateMixerStreamControl *control)
 {
-        g_return_if_fail (GVC_STREAM_STATUS_ICON (icon));
+        g_return_if_fail (GVC_IS_STREAM_STATUS_ICON (icon));
 
         if (icon->priv->control == control)
                 return;


### PR DESCRIPTION
The `g_return*_if_fail()` calls should use `PREFIX_IS_TYPE_NAME` [1], which returns whether the given instance is of the right type, not `PREFIX_TYPE_NAME` [2], which checks whether the given instance if of the right type, warns if not, and returns the passed-in instance unchanged.

Using the wrong one means the returned value is the passed-in pointer, and thus passes the `g_return*_if_fail()` whenever the pointer is non-NULL, no matter whether it's of the right type or not.

A warning would still be emitted by `g_type_check_instance_cast()`, but the execution wouldn't get short-circuited.

[1] calls `g_type_check_instance_is_a()`
[2] calls `g_type_check_instance_cast()`