### PR TITLE
fix building with libxml 2.12.0

### DIFF
--- a/mate-volume-control/gvc-sound-theme-chooser.c
+++ b/mate-volume-control/gvc-sound-theme-chooser.c
@@ -35,6 +35,7 @@
 #include <gtk/gtk.h>
 #include <canberra-gtk.h>
 #include <libxml/tree.h>
+#include <libxml/parser.h>
 
 #include "gvc-sound-theme-chooser.h"
 #include "sound-theme-file-utils.h"


### PR DESCRIPTION
```
gvc-sound-theme-chooser.c:462:15: error: implicit declaration of function ‘xmlParseFile’; did you mean ‘xmlSaveFile’? [-Werror=implicit-function-declaration]
462 |         doc = xmlParseFile (filename);
|               ^~~~~~~~~~~~
|               xmlSaveFile
gvc-sound-theme-chooser.c:462:13: warning: assignment to ‘xmlDocPtr’ {aka ‘struct _xmlDoc *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
462 |         doc = xmlParseFile (filename);
|             ^
```
Successful build with libxml-2.12.0 from fedora-rawhide at fedora build-server https://koji.fedoraproject.org/koji/taskinfo?taskID=109500185
https://src.fedoraproject.org/rpms/mate-media/blob/rawhide/f/mate-media.spec#_14