### PR TITLE
Wayland: Show the sound capplet in the control center

### DIFF
--- a/data/mate-volume-control.desktop.in.in
+++ b/data/mate-volume-control.desktop.in.in
@@ -10,7 +10,7 @@ StartupNotify=true
 Categories=GTK;Settings;HardwareSettings;AudioVideo;Audio;Mixer;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=MATE;volume;control;mixer;settings;sound;events;
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;MATE-wayland;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-media
 X-MATE-Bugzilla-Component=mate-volume-control


### PR DESCRIPTION
Use` OnlyShowIn=MATE;MATE-wayland;` instead of ` OnlyShowIn=MATE;`in the .desktop file so mate-control-center can show the capplet same as in x11. It works in both sessions