### PR TITLE
Allow to theme volume applet

### DIFF
--- a/mate-volume-control/gvc-applet.c
+++ b/mate-volume-control/gvc-applet.c
@@ -53,13 +53,16 @@ static const gchar *icon_names_input[] = {
 
 static void menu_output_mute (GtkAction *action, GvcApplet *applet);
 static void menu_activate_open_volume_control (GtkAction *action, GvcApplet *applet);
+
+// @todo like in mate-volume-control-status-icon: label = g_strdup_printf ("%s %s", _("Mute/Unmute"), icon->priv->display_name);
+// @todo mute/unmute output OR input not output AND output
 static const GtkActionEntry applet_menu_actions [] = {
-        { "Preferences", APPLET_ICON, N_("_Sound Preferences"), NULL, NULL, G_CALLBACK(menu_activate_open_volume_control) },
-        { "MuteOutput", "audio-volume-muted", N_("Mute Output"), NULL, NULL, G_CALLBACK (menu_output_mute) }
+        { "MuteOutput", "audio-volume-muted", N_("Mute Output"), NULL, NULL, G_CALLBACK (menu_output_mute) },
+        { "Preferences", APPLET_ICON, N_("_Sound Preferences"), NULL, NULL, G_CALLBACK (menu_activate_open_volume_control) }
 };
 
-static char *ui = "<menuitem name='Preferences' action='Preferences' />"
-                  "<menuitem name='MuteOutput' action='MuteOutput' />";
+static char *ui = "<menuitem name='MuteOutput' action='MuteOutput' />"
+                  "<menuitem name='Preferences' action='Preferences' />";
 
 struct _GvcAppletPrivate
 {
@@ -529,6 +532,8 @@ gvc_applet_fill (GvcApplet *applet, MatePanelApplet* applet_widget)
                 applet->priv->box = GTK_BOX (gtk_box_new (GTK_ORIENTATION_VERTICAL, 0));
         break;
         }
+
+        gtk_style_context_add_class (gtk_widget_get_style_context (GTK_WIDGET (applet->priv->applet)), "mate-volume-applet");
 
         /* Define an initial size and orientation */
         gvc_stream_applet_icon_set_size (applet->priv->icon_input, mate_panel_applet_get_size (applet->priv->applet));

--- a/mate-volume-control/gvc-stream-applet-icon.c
+++ b/mate-volume-control/gvc-stream-applet-icon.c
@@ -84,6 +84,7 @@ popup_dock (GvcStreamAppletIcon *icon, guint time)
         screen = gtk_widget_get_screen (GTK_WIDGET (icon));
         gtk_widget_get_allocation (GTK_WIDGET (icon), &allocation);
         gdk_window_get_origin (gtk_widget_get_window (GTK_WIDGET (icon)), &allocation.x, &allocation.y);
+        gtk_widget_set_state_flags (GTK_WIDGET (icon), GTK_STATE_FLAG_CHECKED, FALSE);
 
         /* position roughly */
         gtk_window_set_screen (GTK_WINDOW (icon->priv->dock), screen);
@@ -309,6 +310,7 @@ gvc_icon_release_grab (GvcStreamAppletIcon *icon, GdkEventButton *event)
         gtk_grab_remove (icon->priv->dock);
 
         /* Hide again */
+        gtk_widget_unset_state_flags (GTK_WIDGET (icon), GTK_STATE_FLAG_CHECKED);
         gtk_widget_hide (icon->priv->dock);
 }
 
@@ -336,6 +338,7 @@ popdown_dock (GvcStreamAppletIcon *icon)
         gdk_seat_ungrab (seat);
 
         /* Hide again */
+        gtk_widget_unset_state_flags (GTK_WIDGET (icon), GTK_STATE_FLAG_CHECKED);
         gtk_widget_hide (icon->priv->dock);
 }
 
@@ -762,6 +765,7 @@ gvc_stream_applet_icon_init (GvcStreamAppletIcon *icon)
 
         icon->priv->image = GTK_IMAGE (gtk_image_new ());
         gtk_container_add (GTK_CONTAINER (icon), GTK_WIDGET (icon->priv->image));
+        gtk_style_context_add_class (gtk_widget_get_style_context (GTK_WIDGET (icon)), "menu-button"); // icon = volume-applet
 
         g_signal_connect (GTK_WIDGET (icon),
                           "button-press-event",


### PR DESCRIPTION
This is not working for the volume icon in notification area, it's only for the volume applet. Continuation of the idea of https://github.com/mate-desktop/mate-panel/pull/1474.

<img width="939" height="352" alt="image" src="https://github.com/user-attachments/assets/baf039bb-0900-437d-9126-9797c897d219" />

```css
.mate-panel-menu-bar .mate-volume-applet .menu-button:checked { background:yellow; }
```