### PR TITLE
Add MPRIS media controls to the volume applet and status icon

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -31,3 +31,8 @@ i18n.merge_file(
   install: true,
   install_dir: join_paths(get_option('sysconfdir'), 'xdg', 'autostart')
 )
+
+install_data(
+  'org.mate.volume-control.gschema.xml',
+  install_dir: join_paths(mm_datadir, 'glib-2.0', 'schemas')
+)

--- a/data/org.mate.volume-control.gschema.xml
+++ b/data/org.mate.volume-control.gschema.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.mate.volume-control" path="/org/mate/volume-control/">
+    <key name="show-track-in-panel" type="b">
+      <default>false</default>
+      <summary>Show track title in the panel</summary>
+      <description>Whether the volume applet should show the current track next to the panel icon.</description>
+    </key>
+    <key name="show-player-controls" type="b">
+      <default>true</default>
+      <summary>Show media player controls</summary>
+      <description>Whether the applet popup should include MPRIS media player controls.</description>
+    </key>
+    <key name="middle-click-action" type="s">
+      <default>'mute-output'</default>
+      <summary>Middle click action</summary>
+      <description>Action for middle click: mute-all, mute-output, mute-input, or player.</description>
+    </key>
+    <key name="horizontal-scroll-controls" type="b">
+      <default>true</default>
+      <summary>Horizontal scroll controls media</summary>
+      <description>Whether horizontal scroll events on the applet move to the previous or next track.</description>
+    </key>
+    <key name="known-players" type="as">
+      <default>[]</default>
+      <summary>Known media players</summary>
+      <description>Desktop entry IDs discovered from MPRIS players.</description>
+    </key>
+    <key name="tooltip-show-volume" type="b">
+      <default>true</default>
+      <summary>Show volume in tooltip</summary>
+      <description>Whether the applet tooltip should include volume information.</description>
+    </key>
+    <key name="tooltip-show-player" type="b">
+      <default>false</default>
+      <summary>Show player in tooltip</summary>
+      <description>Whether the applet tooltip should include the active media player and track.</description>
+    </key>
+  </schema>
+</schemalist>

--- a/mate-volume-control/gvc-applet.c
+++ b/mate-volume-control/gvc-applet.c
@@ -27,13 +27,18 @@
 #include <glib.h>
 #include <glib/gi18n-lib.h>
 #include <glib-object.h>
+#include <gio/gdesktopappinfo.h>
 #include <gtk/gtk.h>
 
 #include <libmatemixer/matemixer.h>
 #include <mate-panel-applet.h>
 
 #include "gvc-applet.h"
+#include "gvc-mpris-manager.h"
+#include "gvc-player-widget.h"
 #include "gvc-stream-applet-icon.h"
+
+const gchar *mate_panel_applet_get_object_path (MatePanelApplet *applet);
 
 static const gchar *icon_names_output[] = {
         "audio-volume-muted",
@@ -54,8 +59,6 @@ static const gchar *icon_names_input[] = {
 static void menu_output_mute (GtkAction *action, GvcApplet *applet);
 static void menu_activate_open_volume_control (GtkAction *action, GvcApplet *applet);
 
-// @todo like in mate-volume-control-status-icon: label = g_strdup_printf ("%s %s", _("Mute/Unmute"), icon->priv->display_name);
-// @todo mute/unmute output OR input not output AND output
 static const GtkActionEntry applet_menu_actions [] = {
         { "MuteOutput", "audio-volume-muted", N_("Mute Output"), NULL, NULL, G_CALLBACK (menu_output_mute) },
         { "Preferences", APPLET_ICON, N_("_Sound Preferences"), NULL, NULL, G_CALLBACK (menu_activate_open_volume_control) }
@@ -72,6 +75,12 @@ struct _GvcAppletPrivate
         MateMixerContext    *context;
         MateMixerStream     *output;
         MateMixerStream     *input;
+        GvcMprisManager     *mpris_manager;
+        GvcMprisPlayer      *active_player;
+        GvcMprisPlayer      *selected_player;
+        GtkWidget           *player_widget;
+        GtkLabel            *track_label;
+        GSettings           *applet_settings;
 
         MatePanelApplet     *applet;
         GtkBox              *box;
@@ -79,6 +88,62 @@ struct _GvcAppletPrivate
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE (GvcApplet, gvc_applet, G_TYPE_OBJECT)
+
+static void update_active_player (GvcApplet *applet);
+
+static GSettings *
+new_applet_settings (void)
+{
+        GSettingsSchemaSource *source;
+        GSettingsSchema       *schema;
+
+        source = g_settings_schema_source_get_default ();
+        if (source == NULL)
+                return NULL;
+
+        schema = g_settings_schema_source_lookup (source,
+                                                  "org.mate.volume-control",
+                                                  TRUE);
+        if (schema == NULL)
+                return NULL;
+
+        g_settings_schema_unref (schema);
+
+        return g_settings_new ("org.mate.volume-control");
+}
+
+static gboolean
+settings_get_boolean (GvcApplet   *applet,
+                      const gchar *key,
+                      gboolean     fallback)
+{
+        if (applet->priv->applet_settings == NULL)
+                return fallback;
+
+        return g_settings_get_boolean (applet->priv->applet_settings, key);
+}
+
+static gboolean
+is_recording_application_control (MateMixerStreamControl *control)
+{
+        MateMixerAppInfo *app_info;
+        const gchar      *app_id;
+
+        if (mate_mixer_stream_control_get_role (control) != MATE_MIXER_STREAM_CONTROL_ROLE_APPLICATION)
+                return FALSE;
+
+        app_info = mate_mixer_stream_control_get_app_info (control);
+        if (app_info == NULL)
+                return TRUE;
+
+        app_id = mate_mixer_app_info_get_id (app_info);
+        if (app_id == NULL)
+                return TRUE;
+
+        return strcmp (app_id, "org.mate.VolumeControl") != 0 &&
+               strcmp (app_id, "org.gnome.VolumeControl") != 0 &&
+               strcmp (app_id, "org.PulseAudio.pavucontrol") != 0;
+}
 
 static void
 update_icon_input (GvcApplet *applet)
@@ -89,12 +154,13 @@ update_icon_input (GvcApplet *applet)
         /* Enable the input icon in case there is an input stream present and there
          * is a non-mixer application using the input */
         if (applet->priv->input != NULL) {
-                const gchar *app_id;
+                const gchar *app_id = NULL;
+                const gchar *stream_name;
                 const GList *inputs = mate_mixer_stream_list_controls (applet->priv->input);
 
                 control = mate_mixer_stream_get_default_control (applet->priv->input);
 
-                const gchar *stream_name = mate_mixer_stream_get_name (applet->priv->input);
+                stream_name = mate_mixer_stream_get_name (applet->priv->input);
                 g_debug ("Got stream name %s", stream_name);
                 if (g_str_has_suffix (stream_name, ".monitor")) {
                         inputs = NULL;
@@ -103,48 +169,72 @@ update_icon_input (GvcApplet *applet)
 
                 while (inputs != NULL) {
                         MateMixerStreamControl *input = MATE_MIXER_STREAM_CONTROL (inputs->data);
-                        MateMixerStreamControlRole role = mate_mixer_stream_control_get_role (input);
 
-                        if (role == MATE_MIXER_STREAM_CONTROL_ROLE_APPLICATION) {
-                                MateMixerAppInfo *app_info = mate_mixer_stream_control_get_app_info (input);
+                        if (is_recording_application_control (input)) {
+                                MateMixerAppInfo *app_info;
 
-                                app_id = mate_mixer_app_info_get_id (app_info);
-                                if (app_id == NULL) {
-                                        /* A recording application which has no
-                                         * identifier set */
+                                app_info = mate_mixer_stream_control_get_app_info (input);
+                                app_id = app_info != NULL ? mate_mixer_app_info_get_id (app_info) : NULL;
+                                if (app_id != NULL)
+                                        g_debug ("Found a recording application %s", app_id);
+                                else
                                         g_debug ("Found a recording application control %s",
                                                  mate_mixer_stream_control_get_label (input));
 
-                                        if (G_UNLIKELY (control == NULL)) {
-                                                /* In the unlikely case when there is no
-                                                 * default input control, use the application
-                                                 * control for the icon */
-                                                control = input;
-                                        }
-                                        show = TRUE;
-                                        break;
-                                }
+                                if (G_UNLIKELY (control == NULL))
+                                        control = input;
 
-                                if (strcmp (app_id, "org.mate.VolumeControl") != 0 &&
-                                    strcmp (app_id, "org.gnome.VolumeControl") != 0 &&
-                                    strcmp (app_id, "org.PulseAudio.pavucontrol") != 0) {
-                                        g_debug ("Found a recording application %s", app_id);
-
-                                        if (G_UNLIKELY (control == NULL))
-                                                control = input;
-
-                                        show = TRUE;
-                                        break;
-                                }
+                                show = TRUE;
+                                break;
                         }
                         inputs = inputs->next;
                 }
-
-                if (show == TRUE)
-                        g_debug ("Input icon enabled");
-                else
-                        g_debug ("There is no recording application, input icon disabled");
         }
+
+        if (!show && applet->priv->context != NULL) {
+                const GList *streams;
+
+                streams = mate_mixer_context_list_streams (applet->priv->context);
+                while (streams != NULL && !show) {
+                        MateMixerStream *stream = MATE_MIXER_STREAM (streams->data);
+                        const gchar     *name;
+                        const GList     *inputs;
+
+                        if (stream == applet->priv->input ||
+                            mate_mixer_stream_get_direction (stream) != MATE_MIXER_DIRECTION_INPUT) {
+                                streams = streams->next;
+                                continue;
+                        }
+
+                        name = mate_mixer_stream_get_name (stream);
+                        if (name != NULL && g_str_has_suffix (name, ".monitor")) {
+                                streams = streams->next;
+                                continue;
+                        }
+
+                        inputs = mate_mixer_stream_list_controls (stream);
+                        while (inputs != NULL) {
+                                MateMixerStreamControl *input = MATE_MIXER_STREAM_CONTROL (inputs->data);
+
+                                if (is_recording_application_control (input)) {
+                                        control = mate_mixer_stream_get_default_control (stream);
+                                        if (control == NULL)
+                                                control = input;
+                                        show = TRUE;
+                                        break;
+                                }
+
+                                inputs = inputs->next;
+                        }
+
+                        streams = streams->next;
+                }
+        }
+
+        if (show == TRUE)
+                g_debug ("Input icon enabled");
+        else
+                g_debug ("There is no recording application, input icon disabled");
 
         gvc_stream_applet_icon_set_control (applet->priv->icon_input, control);
 
@@ -171,6 +261,524 @@ update_icon_output (GvcApplet *applet)
                 g_debug ("There is no output stream/control, output icon disabled");
                 gtk_widget_set_visible (GTK_WIDGET (applet->priv->icon_output), FALSE);
         }
+}
+
+static void
+update_track_label (GvcApplet *applet)
+{
+        MatePanelAppletOrient orient;
+        const gchar          *title;
+        const gchar          *artist;
+        gchar                *text = NULL;
+
+        if (applet->priv->track_label == NULL)
+                return;
+
+        if (!settings_get_boolean (applet, "show-track-in-panel", FALSE) ||
+            applet->priv->active_player == NULL ||
+            applet->priv->applet == NULL) {
+                gtk_widget_hide (GTK_WIDGET (applet->priv->track_label));
+                return;
+        }
+
+        orient = mate_panel_applet_get_orient (applet->priv->applet);
+        if (orient == MATE_PANEL_APPLET_ORIENT_LEFT ||
+            orient == MATE_PANEL_APPLET_ORIENT_RIGHT) {
+                gtk_widget_hide (GTK_WIDGET (applet->priv->track_label));
+                return;
+        }
+
+        title = gvc_mpris_player_get_title (applet->priv->active_player);
+        artist = gvc_mpris_player_get_artist (applet->priv->active_player);
+
+        if (title != NULL && title[0] != '\0' &&
+            artist != NULL && artist[0] != '\0')
+                text = g_strdup_printf ("%s - %s", title, artist);
+        else if (title != NULL && title[0] != '\0')
+                text = g_strdup (title);
+        else if (artist != NULL && artist[0] != '\0')
+                text = g_strdup (artist);
+
+        if (text == NULL) {
+                gtk_widget_hide (GTK_WIDGET (applet->priv->track_label));
+                return;
+        }
+
+        gtk_label_set_text (applet->priv->track_label, text);
+        gtk_widget_set_tooltip_text (GTK_WIDGET (applet->priv->track_label), text);
+        gtk_widget_show (GTK_WIDGET (applet->priv->track_label));
+
+        g_free (text);
+}
+
+static void
+update_player_selector (GvcApplet *applet)
+{
+        GList *players;
+
+        players = gvc_mpris_manager_get_players (applet->priv->mpris_manager);
+        gvc_player_widget_set_players (GVC_PLAYER_WIDGET (applet->priv->player_widget),
+                                       players,
+                                       applet->priv->active_player);
+        g_list_free (players);
+}
+
+static void
+on_player_widget_player_selected (GvcPlayerWidget *widget,
+                                  GvcMprisPlayer  *player,
+                                  GvcApplet       *applet)
+{
+        g_clear_object (&applet->priv->selected_player);
+        if (player != NULL)
+                applet->priv->selected_player = g_object_ref (player);
+
+        update_active_player (applet);
+}
+
+static void
+on_mpris_player_changed (GvcMprisPlayer *player,
+                         GvcApplet      *applet)
+{
+        update_active_player (applet);
+}
+
+static void
+update_active_player (GvcApplet *applet)
+{
+        GvcMprisPlayer *player;
+
+        player = NULL;
+        if (applet->priv->selected_player != NULL &&
+            gvc_mpris_player_is_ready (applet->priv->selected_player))
+                player = applet->priv->selected_player;
+        if (player == NULL)
+                player = gvc_mpris_manager_get_best_player (applet->priv->mpris_manager);
+
+        if (player == applet->priv->active_player) {
+                if (player != NULL) {
+                        if (settings_get_boolean (applet, "show-player-controls", TRUE))
+                                gvc_player_widget_set_player (GVC_PLAYER_WIDGET (applet->priv->player_widget), player);
+                        else
+                                gvc_player_widget_set_player (GVC_PLAYER_WIDGET (applet->priv->player_widget), NULL);
+                        gvc_stream_applet_icon_set_player_widget_visible (applet->priv->icon_output,
+                                                                          settings_get_boolean (applet, "show-player-controls", TRUE));
+                }
+                update_player_selector (applet);
+                update_track_label (applet);
+                return;
+        }
+
+        g_clear_object (&applet->priv->active_player);
+        if (player != NULL)
+                applet->priv->active_player = g_object_ref (player);
+
+        if (settings_get_boolean (applet, "show-player-controls", TRUE))
+                gvc_player_widget_set_player (GVC_PLAYER_WIDGET (applet->priv->player_widget),
+                                              applet->priv->active_player);
+        else
+                gvc_player_widget_set_player (GVC_PLAYER_WIDGET (applet->priv->player_widget), NULL);
+        gvc_stream_applet_icon_set_mpris_player (applet->priv->icon_output,
+                                                 applet->priv->active_player);
+        gvc_stream_applet_icon_set_player_widget_visible (applet->priv->icon_output,
+                                                          applet->priv->active_player != NULL &&
+                                                          settings_get_boolean (applet, "show-player-controls", TRUE));
+        update_player_selector (applet);
+        update_track_label (applet);
+}
+
+static void
+on_player_menu_item_toggled (GtkCheckMenuItem *item,
+                             GvcApplet        *applet)
+{
+        GvcMprisPlayer *player;
+
+        if (!gtk_check_menu_item_get_active (item))
+                return;
+
+        player = g_object_get_data (G_OBJECT (item), "gvc-player");
+        g_clear_object (&applet->priv->selected_player);
+        if (player != NULL)
+                applet->priv->selected_player = g_object_ref (player);
+
+        update_active_player (applet);
+}
+
+static void
+on_stream_menu_item_toggled (GtkCheckMenuItem *item,
+                             GvcApplet        *applet)
+{
+        MateMixerStream *stream;
+        MateMixerDirection direction;
+
+        if (!gtk_check_menu_item_get_active (item))
+                return;
+
+        stream = g_object_get_data (G_OBJECT (item), "gvc-stream");
+        if (stream == NULL)
+                return;
+
+        direction = mate_mixer_stream_get_direction (stream);
+        if (direction == MATE_MIXER_DIRECTION_OUTPUT)
+                mate_mixer_context_set_default_output_stream (applet->priv->context, stream);
+        else if (direction == MATE_MIXER_DIRECTION_INPUT)
+                mate_mixer_context_set_default_input_stream (applet->priv->context, stream);
+}
+
+static void
+on_launch_player_menu_item_activate (GtkMenuItem *item,
+                                     GvcApplet   *applet)
+{
+        const gchar     *desktop_entry;
+        GDesktopAppInfo *app_info;
+        GError          *error = NULL;
+
+        desktop_entry = g_object_get_data (G_OBJECT (item), "desktop-entry");
+        if (desktop_entry == NULL)
+                return;
+
+        app_info = g_desktop_app_info_new (desktop_entry);
+        if (app_info == NULL && !g_str_has_suffix (desktop_entry, ".desktop")) {
+                gchar *desktop_id;
+
+                desktop_id = g_strconcat (desktop_entry, ".desktop", NULL);
+                app_info = g_desktop_app_info_new (desktop_id);
+                g_free (desktop_id);
+        }
+
+        if (app_info == NULL)
+                return;
+
+        g_app_info_launch (G_APP_INFO (app_info), NULL, NULL, &error);
+        if (error != NULL)
+                g_error_free (error);
+
+        g_object_unref (app_info);
+}
+
+static void
+on_custom_menu_mute_activate (GtkMenuItem *item,
+                              GvcApplet   *applet)
+{
+        gboolean is_muted;
+
+        is_muted = gvc_stream_applet_icon_get_mute (applet->priv->icon_output);
+        gvc_stream_applet_icon_set_mute (applet->priv->icon_output, !is_muted);
+}
+
+static void
+on_custom_menu_preferences_activate (GtkMenuItem *item,
+                                     GvcApplet   *applet)
+{
+        menu_activate_open_volume_control (NULL, applet);
+}
+
+static GtkWidget *
+new_image_menu_item (const gchar *label,
+                     const gchar *icon_name)
+{
+        GtkWidget *item;
+        GtkWidget *image;
+
+        item = gtk_image_menu_item_new_with_label (label);
+        image = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU);
+        gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (item), image);
+        gtk_image_menu_item_set_always_show_image (GTK_IMAGE_MENU_ITEM (item), TRUE);
+
+        return item;
+}
+
+static void
+emit_panel_applet_signal (GvcApplet   *applet,
+                          const gchar *signal_name)
+{
+        GDBusConnection *connection = NULL;
+        const gchar     *object_path;
+        GError          *error = NULL;
+
+        if (applet->priv->applet == NULL)
+                return;
+
+        object_path = mate_panel_applet_get_object_path (applet->priv->applet);
+        if (object_path == NULL)
+                return;
+
+        if (g_object_class_find_property (G_OBJECT_GET_CLASS (applet->priv->applet), "connection") == NULL)
+                return;
+
+        g_object_get (applet->priv->applet, "connection", &connection, NULL);
+        if (connection == NULL)
+                return;
+
+        g_dbus_connection_emit_signal (connection,
+                                       NULL,
+                                       object_path,
+                                       "org.mate.panel.applet.Applet",
+                                       signal_name,
+                                       NULL,
+                                       &error);
+        if (error != NULL)
+                g_error_free (error);
+
+        g_object_unref (connection);
+}
+
+static void
+on_panel_menu_remove_activate (GtkMenuItem *item,
+                               GvcApplet   *applet)
+{
+        emit_panel_applet_signal (applet, "RemoveFromPanel");
+}
+
+static void
+on_panel_menu_move_activate (GtkMenuItem *item,
+                             GvcApplet   *applet)
+{
+        emit_panel_applet_signal (applet, "Move");
+}
+
+static void
+on_panel_menu_lock_activate (GtkMenuItem *item,
+                             GvcApplet   *applet)
+{
+        if (applet->priv->applet != NULL &&
+            g_object_class_find_property (G_OBJECT_GET_CLASS (applet->priv->applet), "locked") != NULL)
+                g_object_set (applet->priv->applet,
+                              "locked",
+                              gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM (item)),
+                              NULL);
+}
+
+static void
+append_stream_menu_items (GvcApplet          *applet,
+                          GtkWidget          *submenu,
+                          MateMixerDirection  direction)
+{
+        const GList *streams;
+        GSList      *group = NULL;
+
+        streams = mate_mixer_context_list_streams (applet->priv->context);
+        while (streams != NULL) {
+                MateMixerStream *stream = MATE_MIXER_STREAM (streams->data);
+
+                if (mate_mixer_stream_get_direction (stream) == direction) {
+                        GtkWidget       *item;
+                        MateMixerStream *active;
+                        const gchar     *label;
+
+                        active = direction == MATE_MIXER_DIRECTION_OUTPUT ?
+                                mate_mixer_context_get_default_output_stream (applet->priv->context) :
+                                mate_mixer_context_get_default_input_stream (applet->priv->context);
+                        label = mate_mixer_stream_get_label (stream);
+                        if (label == NULL || label[0] == '\0')
+                                label = mate_mixer_stream_get_name (stream);
+
+                        item = gtk_radio_menu_item_new_with_label (group, label);
+                        group = gtk_radio_menu_item_get_group (GTK_RADIO_MENU_ITEM (item));
+                        gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (item), stream == active);
+                        g_object_set_data_full (G_OBJECT (item), "gvc-stream", g_object_ref (stream), g_object_unref);
+                        g_signal_connect (item, "toggled", G_CALLBACK (on_stream_menu_item_toggled), applet);
+                        gtk_menu_shell_append (GTK_MENU_SHELL (submenu), item);
+                }
+
+                streams = streams->next;
+        }
+}
+
+static gboolean
+on_applet_icon_context_menu (GtkWidget      *widget,
+                             GdkEventButton *event,
+                             GvcApplet      *applet)
+{
+        GtkWidget *menu;
+        GtkWidget *item;
+        GtkWidget *submenu;
+        GList     *players;
+        GList     *l;
+        GSList    *player_group = NULL;
+        gboolean   locked = FALSE;
+
+        if (event->type != GDK_BUTTON_PRESS || event->button != 3)
+                return FALSE;
+
+        menu = gtk_menu_new ();
+
+        item = new_image_menu_item (_("Media Players"), "applications-multimedia");
+        submenu = gtk_menu_new ();
+        players = gvc_mpris_manager_get_players (applet->priv->mpris_manager);
+        for (l = players; l != NULL; l = l->next) {
+                GvcMprisPlayer *player = GVC_MPRIS_PLAYER (l->data);
+                GtkWidget      *player_item;
+                const gchar    *label;
+
+                if (!gvc_mpris_player_is_ready (player))
+                        continue;
+
+                label = gvc_mpris_player_get_identity (player);
+                player_item = gtk_radio_menu_item_new_with_label (player_group,
+                                                                  label != NULL && label[0] != '\0' ?
+                                                                  label :
+                                                                  gvc_mpris_player_get_bus_name (player));
+                player_group = gtk_radio_menu_item_get_group (GTK_RADIO_MENU_ITEM (player_item));
+                gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (player_item), player == applet->priv->active_player);
+                g_object_set_data_full (G_OBJECT (player_item), "gvc-player", g_object_ref (player), g_object_unref);
+                g_signal_connect (player_item, "toggled", G_CALLBACK (on_player_menu_item_toggled), applet);
+                gtk_menu_shell_append (GTK_MENU_SHELL (submenu), player_item);
+        }
+        g_list_free (players);
+        gtk_menu_item_set_submenu (GTK_MENU_ITEM (item), submenu);
+        gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+        if (applet->priv->applet_settings != NULL) {
+                gchar **known;
+                gint    i;
+
+                item = new_image_menu_item (_("Launch Player"), "applications-multimedia");
+                submenu = gtk_menu_new ();
+                known = g_settings_get_strv (applet->priv->applet_settings, "known-players");
+                for (i = 0; known != NULL && known[i] != NULL; i++) {
+                        GtkWidget *launcher_item;
+
+                        launcher_item = gtk_menu_item_new_with_label (known[i]);
+                        g_object_set_data_full (G_OBJECT (launcher_item), "desktop-entry", g_strdup (known[i]), g_free);
+                        g_signal_connect (launcher_item, "activate", G_CALLBACK (on_launch_player_menu_item_activate), applet);
+                        gtk_menu_shell_append (GTK_MENU_SHELL (submenu), launcher_item);
+                }
+                g_strfreev (known);
+                gtk_menu_item_set_submenu (GTK_MENU_ITEM (item), submenu);
+                gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+        }
+
+        item = new_image_menu_item (_("Output Device"), "audio-speakers");
+        submenu = gtk_menu_new ();
+        append_stream_menu_items (applet, submenu, MATE_MIXER_DIRECTION_OUTPUT);
+        gtk_menu_item_set_submenu (GTK_MENU_ITEM (item), submenu);
+        gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+        item = new_image_menu_item (_("Input Device"), "audio-input-microphone");
+        submenu = gtk_menu_new ();
+        append_stream_menu_items (applet, submenu, MATE_MIXER_DIRECTION_INPUT);
+        gtk_menu_item_set_submenu (GTK_MENU_ITEM (item), submenu);
+        gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+        gtk_menu_shell_append (GTK_MENU_SHELL (menu), gtk_separator_menu_item_new ());
+
+        item = new_image_menu_item (gvc_stream_applet_icon_get_mute (applet->priv->icon_output) ?
+                                    _("Unmute Output") :
+                                    _("Mute Output"),
+                                    gvc_stream_applet_icon_get_mute (applet->priv->icon_output) ?
+                                    "audio-volume-medium" :
+                                    "audio-volume-muted");
+        g_signal_connect (item, "activate", G_CALLBACK (on_custom_menu_mute_activate), applet);
+        gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+        item = new_image_menu_item (_("Sound Preferences"), APPLET_ICON);
+        g_signal_connect (item, "activate", G_CALLBACK (on_custom_menu_preferences_activate), applet);
+        gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+        gtk_menu_shell_append (GTK_MENU_SHELL (menu), gtk_separator_menu_item_new ());
+
+        item = new_image_menu_item (_("_Remove From Panel"), "list-remove");
+        gtk_menu_item_set_use_underline (GTK_MENU_ITEM (item), TRUE);
+        g_signal_connect (item, "activate", G_CALLBACK (on_panel_menu_remove_activate), applet);
+        gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+        item = gtk_menu_item_new_with_mnemonic (_("_Move"));
+        gtk_menu_item_set_use_underline (GTK_MENU_ITEM (item), TRUE);
+        g_signal_connect (item, "activate", G_CALLBACK (on_panel_menu_move_activate), applet);
+        gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+        gtk_menu_shell_append (GTK_MENU_SHELL (menu), gtk_separator_menu_item_new ());
+
+        if (applet->priv->applet != NULL &&
+            g_object_class_find_property (G_OBJECT_GET_CLASS (applet->priv->applet), "locked") != NULL)
+                g_object_get (applet->priv->applet, "locked", &locked, NULL);
+
+        item = gtk_check_menu_item_new_with_mnemonic (_("Loc_k To Panel"));
+        gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (item), locked);
+        g_signal_connect (item, "activate", G_CALLBACK (on_panel_menu_lock_activate), applet);
+        gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+        g_signal_connect (menu, "selection-done", G_CALLBACK (gtk_widget_destroy), NULL);
+
+        gtk_widget_show_all (menu);
+        gtk_menu_popup_at_pointer (GTK_MENU (menu), (GdkEvent *) event);
+
+        return TRUE;
+}
+
+static void
+remember_player (GvcApplet      *applet,
+                 GvcMprisPlayer *player)
+{
+        const gchar *desktop_entry;
+        gchar      **known;
+        gboolean     found = FALSE;
+        gint         i;
+
+        if (applet->priv->applet_settings == NULL)
+                return;
+
+        desktop_entry = gvc_mpris_player_get_desktop_entry (player);
+        if (desktop_entry == NULL || desktop_entry[0] == '\0')
+                return;
+
+        known = g_settings_get_strv (applet->priv->applet_settings, "known-players");
+        for (i = 0; known != NULL && known[i] != NULL; i++) {
+                if (g_strcmp0 (known[i], desktop_entry) == 0) {
+                        found = TRUE;
+                        break;
+                }
+        }
+
+        if (!found) {
+                GPtrArray *array;
+
+                array = g_ptr_array_new_with_free_func (g_free);
+                for (i = 0; known != NULL && known[i] != NULL; i++)
+                        g_ptr_array_add (array, g_strdup (known[i]));
+                g_ptr_array_add (array, g_strdup (desktop_entry));
+                g_ptr_array_add (array, NULL);
+                g_settings_set_strv (applet->priv->applet_settings,
+                                     "known-players",
+                                     (const gchar * const *) array->pdata);
+                g_ptr_array_free (array, TRUE);
+        }
+
+        g_strfreev (known);
+}
+
+static void
+on_mpris_player_added (GvcMprisManager *manager,
+                       GvcMprisPlayer  *player,
+                       GvcApplet       *applet)
+{
+        remember_player (applet, player);
+
+        g_signal_connect (player, "status-changed", G_CALLBACK (on_mpris_player_changed), applet);
+        g_signal_connect (player, "metadata-changed", G_CALLBACK (on_mpris_player_changed), applet);
+        g_signal_connect (player, "capabilities-changed", G_CALLBACK (on_mpris_player_changed), applet);
+
+        update_active_player (applet);
+}
+
+static void
+on_applet_settings_changed (GSettings *settings,
+                            gchar     *key,
+                            GvcApplet *applet)
+{
+        update_active_player (applet);
+}
+
+static void
+on_mpris_player_removed (GvcMprisManager *manager,
+                         const gchar     *bus_name,
+                         GvcApplet       *applet)
+{
+        if (applet->priv->selected_player != NULL &&
+            g_strcmp0 (gvc_mpris_player_get_bus_name (applet->priv->selected_player), bus_name) == 0)
+                g_clear_object (&applet->priv->selected_player);
+
+        update_active_player (applet);
 }
 
 static void
@@ -237,6 +845,54 @@ on_input_stream_control_removed (MateMixerStream *stream,
         update_icon_input (applet);
 }
 
+static void
+disconnect_input_stream_control_signals (GvcApplet *applet)
+{
+        const GList *streams;
+
+        streams = mate_mixer_context_list_streams (applet->priv->context);
+        while (streams != NULL) {
+                MateMixerStream *stream = MATE_MIXER_STREAM (streams->data);
+
+                if (mate_mixer_stream_get_direction (stream) == MATE_MIXER_DIRECTION_INPUT) {
+                        g_signal_handlers_disconnect_by_func (G_OBJECT (stream),
+                                                              G_CALLBACK (on_input_stream_control_added),
+                                                              applet);
+                        g_signal_handlers_disconnect_by_func (G_OBJECT (stream),
+                                                              G_CALLBACK (on_input_stream_control_removed),
+                                                              applet);
+                }
+
+                streams = streams->next;
+        }
+}
+
+static void
+connect_input_stream_control_signals (GvcApplet *applet)
+{
+        const GList *streams;
+
+        disconnect_input_stream_control_signals (applet);
+
+        streams = mate_mixer_context_list_streams (applet->priv->context);
+        while (streams != NULL) {
+                MateMixerStream *stream = MATE_MIXER_STREAM (streams->data);
+
+                if (mate_mixer_stream_get_direction (stream) == MATE_MIXER_DIRECTION_INPUT) {
+                        g_signal_connect (G_OBJECT (stream),
+                                          "control-added",
+                                          G_CALLBACK (on_input_stream_control_added),
+                                          applet);
+                        g_signal_connect (G_OBJECT (stream),
+                                          "control-removed",
+                                          G_CALLBACK (on_input_stream_control_removed),
+                                          applet);
+                }
+
+                streams = streams->next;
+        }
+}
+
 static gboolean
 update_default_output_stream (GvcApplet *applet)
 {
@@ -284,17 +940,6 @@ update_default_input_stream (GvcApplet *applet)
         }
 
         applet->priv->input = (stream == NULL) ? NULL : g_object_ref (stream);
-        if (applet->priv->input != NULL) {
-                g_signal_connect (G_OBJECT (applet->priv->input),
-                                  "control-added",
-                                  G_CALLBACK (on_input_stream_control_added),
-                                  applet);
-                g_signal_connect (G_OBJECT (applet->priv->input),
-                                  "control-removed",
-                                  G_CALLBACK (on_input_stream_control_removed),
-                                  applet);
-        }
-
         /* Return TRUE if the default input stream has changed */
         return TRUE;
 }
@@ -314,6 +959,7 @@ on_context_state_notify (MateMixerContext *context,
         case MATE_MIXER_STATE_READY:
                 update_default_output_stream (applet);
                 update_default_input_stream (applet);
+                connect_input_stream_control_signals (applet);
 
                 /* Each applet change may affect the visibility of the icons */
                 update_icon_output (applet);
@@ -332,6 +978,7 @@ on_context_default_input_stream_notify (MateMixerContext *context,
         if (update_default_input_stream (applet) == FALSE)
                 return;
 
+        connect_input_stream_control_signals (applet);
         update_icon_input (applet);
 }
 
@@ -344,6 +991,30 @@ on_context_default_output_stream_notify (MateMixerContext *control,
                 return;
 
         update_icon_output (applet);
+}
+
+static void
+on_context_stream_added (MateMixerContext *context,
+                         const gchar      *name,
+                         GvcApplet        *applet)
+{
+        update_default_output_stream (applet);
+        update_default_input_stream (applet);
+        connect_input_stream_control_signals (applet);
+        update_icon_output (applet);
+        update_icon_input (applet);
+}
+
+static void
+on_context_stream_removed (MateMixerContext *context,
+                           const gchar      *name,
+                           GvcApplet        *applet)
+{
+        update_default_output_stream (applet);
+        update_default_input_stream (applet);
+        connect_input_stream_control_signals (applet);
+        update_icon_output (applet);
+        update_icon_input (applet);
 }
 
 void
@@ -378,8 +1049,14 @@ gvc_applet_dispose (GObject *object)
                 g_signal_handlers_disconnect_by_data (G_OBJECT (applet->priv->input), applet);
                 g_clear_object (&applet->priv->input);
         }
+        if (applet->priv->context != NULL)
+                disconnect_input_stream_control_signals (applet);
 
         g_clear_object (&applet->priv->context);
+        g_clear_object (&applet->priv->active_player);
+        g_clear_object (&applet->priv->selected_player);
+        g_clear_object (&applet->priv->mpris_manager);
+        g_clear_object (&applet->priv->applet_settings);
         g_clear_object (&applet->priv->icon_input);
         g_clear_object (&applet->priv->icon_output);
 
@@ -401,11 +1078,30 @@ gvc_applet_init (GvcApplet *applet)
 
         applet->priv->icon_input  = gvc_stream_applet_icon_new (NULL, icon_names_input);
         applet->priv->icon_output = gvc_stream_applet_icon_new (NULL, icon_names_output);
+        applet->priv->applet_settings = new_applet_settings ();
+        gvc_stream_applet_icon_set_applet_settings (applet->priv->icon_input,
+                                                    applet->priv->applet_settings);
+        gvc_stream_applet_icon_set_applet_settings (applet->priv->icon_output,
+                                                    applet->priv->applet_settings);
+        applet->priv->player_widget = gvc_player_widget_new ();
+        gvc_stream_applet_icon_set_player_widget (applet->priv->icon_output,
+                                                  applet->priv->player_widget);
+        g_signal_connect (applet->priv->player_widget,
+                          "player-selected",
+                          G_CALLBACK (on_player_widget_player_selected),
+                          applet);
+        applet->priv->track_label = GTK_LABEL (gtk_label_new (NULL));
+        gtk_widget_set_no_show_all (GTK_WIDGET (applet->priv->track_label), TRUE);
+        gtk_label_set_ellipsize (applet->priv->track_label, PANGO_ELLIPSIZE_END);
+        gtk_label_set_max_width_chars (applet->priv->track_label, 30);
+        gtk_label_set_single_line_mode (applet->priv->track_label, TRUE);
+        gtk_widget_set_margin_start (GTK_WIDGET (applet->priv->track_label), 4);
 
         gvc_stream_applet_icon_set_display_name (applet->priv->icon_input,  _("Input"));
         gvc_stream_applet_icon_set_display_name (applet->priv->icon_output, _("Output"));
 
         applet->priv->context = mate_mixer_context_new ();
+        applet->priv->mpris_manager = gvc_mpris_manager_new ();
 
         mate_mixer_context_set_app_name (applet->priv->context, _("MATE Volume Control Applet"));
 
@@ -425,6 +1121,28 @@ gvc_applet_init (GvcApplet *applet)
                           "notify::default-output-stream",
                           G_CALLBACK (on_context_default_output_stream_notify),
                           applet);
+        g_signal_connect (G_OBJECT (applet->priv->context),
+                          "stream-added",
+                          G_CALLBACK (on_context_stream_added),
+                          applet);
+        g_signal_connect (G_OBJECT (applet->priv->context),
+                          "stream-removed",
+                          G_CALLBACK (on_context_stream_removed),
+                          applet);
+        g_signal_connect (G_OBJECT (applet->priv->mpris_manager),
+                          "player-added",
+                          G_CALLBACK (on_mpris_player_added),
+                          applet);
+        g_signal_connect (G_OBJECT (applet->priv->mpris_manager),
+                          "player-removed",
+                          G_CALLBACK (on_mpris_player_removed),
+                          applet);
+        if (applet->priv->applet_settings != NULL) {
+                g_signal_connect (G_OBJECT (applet->priv->applet_settings),
+                                  "changed",
+                                  G_CALLBACK (on_applet_settings_changed),
+                                  applet);
+        }
 }
 
 GvcApplet *
@@ -481,6 +1199,7 @@ gvc_applet_set_orient(GtkWidget *widget, MatePanelAppletOrient orient, gpointer 
 
         gvc_stream_applet_icon_set_orient (applet->priv->icon_input, orient);
         gvc_stream_applet_icon_set_orient (applet->priv->icon_output, orient);
+        update_track_label (applet);
 }
 
 static void
@@ -517,7 +1236,6 @@ gvc_applet_fill (GvcApplet *applet, MatePanelApplet* applet_widget)
         mate_panel_applet_set_flags (applet_widget, MATE_PANEL_APPLET_EXPAND_MINOR);
 #endif
         applet->priv->applet = applet_widget;
-        /*FIXME: We haved to set this up BEFORE packing in icons. find a way to update this when the applet is moved that works*/
         switch (mate_panel_applet_get_orient (applet->priv->applet)) {
         case MATE_PANEL_APPLET_ORIENT_UP:
                 applet->priv->box = GTK_BOX (gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0));
@@ -544,12 +1262,24 @@ gvc_applet_fill (GvcApplet *applet, MatePanelApplet* applet_widget)
         /* we add the Gtk buttons into the applet */
         gtk_box_pack_start (applet->priv->box, GTK_WIDGET (applet->priv->icon_input), TRUE, TRUE, 2);
         gtk_box_pack_start (applet->priv->box, GTK_WIDGET (applet->priv->icon_output), TRUE, TRUE, 2);
+        gtk_box_pack_start (applet->priv->box, GTK_WIDGET (applet->priv->track_label), FALSE, FALSE, 2);
         gtk_container_add (GTK_CONTAINER (applet->priv->applet), GTK_WIDGET (applet->priv->box));
         gtk_widget_show_all (GTK_WIDGET (applet->priv->applet));
+        update_track_label (applet);
 
         /* Enable 'scroll-event' signal to be received  */
         gtk_widget_add_events (GTK_WIDGET(applet->priv->icon_input), GDK_SCROLL_MASK);
         gtk_widget_add_events (GTK_WIDGET(applet->priv->icon_output), GDK_SCROLL_MASK);
+        gtk_widget_add_events (GTK_WIDGET(applet->priv->icon_input), GDK_BUTTON_PRESS_MASK);
+        gtk_widget_add_events (GTK_WIDGET(applet->priv->icon_output), GDK_BUTTON_PRESS_MASK);
+        g_signal_connect (GTK_WIDGET (applet->priv->icon_input),
+                          "button-press-event",
+                          G_CALLBACK (on_applet_icon_context_menu),
+                          applet);
+        g_signal_connect (GTK_WIDGET (applet->priv->icon_output),
+                          "button-press-event",
+                          G_CALLBACK (on_applet_icon_context_menu),
+                          applet);
 
         /* Update icons on size/orientation changes*/
         g_object_connect (applet->priv->applet,

--- a/mate-volume-control/gvc-mpris-manager.c
+++ b/mate-volume-control/gvc-mpris-manager.c
@@ -1,0 +1,318 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*- */
+
+#include "config.h"
+
+#include <string.h>
+
+#include "gvc-mpris-manager.h"
+
+#define DBUS_NAME "org.freedesktop.DBus"
+#define DBUS_PATH "/org/freedesktop/DBus"
+#define DBUS_IFACE "org.freedesktop.DBus"
+#define MPRIS_PREFIX "org.mpris.MediaPlayer2."
+
+struct _GvcMprisManagerPrivate
+{
+        GDBusConnection *connection;
+        GHashTable      *players;
+        guint            name_owner_changed_id;
+};
+
+enum
+{
+        PLAYER_ADDED,
+        PLAYER_REMOVED,
+        N_SIGNALS
+};
+
+static guint signals[N_SIGNALS] = { 0 };
+
+G_DEFINE_TYPE_WITH_PRIVATE (GvcMprisManager, gvc_mpris_manager, G_TYPE_OBJECT)
+
+static gboolean
+is_mpris_name (const gchar *name)
+{
+        return name != NULL && g_str_has_prefix (name, MPRIS_PREFIX);
+}
+
+static void
+on_player_ready (GvcMprisPlayer  *player,
+                 GvcMprisManager *manager)
+{
+        g_signal_emit (manager, signals[PLAYER_ADDED], 0, player);
+}
+
+static void
+manager_add_player (GvcMprisManager *manager,
+                    const gchar     *bus_name,
+                    const gchar     *owner)
+{
+        GvcMprisPlayer *player;
+
+        if (g_hash_table_contains (manager->priv->players, bus_name))
+                return;
+
+        player = gvc_mpris_player_new (bus_name, owner);
+        g_signal_connect (player, "ready", G_CALLBACK (on_player_ready), manager);
+        g_hash_table_insert (manager->priv->players, g_strdup (bus_name), player);
+}
+
+static void
+manager_remove_player (GvcMprisManager *manager,
+                       const gchar     *bus_name)
+{
+        if (!g_hash_table_contains (manager->priv->players, bus_name))
+                return;
+
+        g_hash_table_remove (manager->priv->players, bus_name);
+        g_signal_emit (manager, signals[PLAYER_REMOVED], 0, bus_name);
+}
+
+static void
+on_get_name_owner_ready (GObject      *source_object,
+                         GAsyncResult *res,
+                         gpointer      user_data)
+{
+        GvcMprisManager *manager;
+        GTask           *task = G_TASK (user_data);
+        GVariant        *result;
+        GError          *error = NULL;
+        gchar           *owner = NULL;
+        gchar           *bus_name;
+
+        manager = g_task_get_source_object (task);
+        bus_name = g_object_get_data (G_OBJECT (task), "gvc-bus-name");
+        result = g_dbus_connection_call_finish (manager->priv->connection, res, &error);
+
+        if (result != NULL) {
+                g_variant_get (result, "(s)", &owner);
+                if (is_mpris_name (bus_name))
+                        manager_add_player (manager, bus_name, owner);
+                g_free (owner);
+                g_variant_unref (result);
+        }
+
+        if (error != NULL)
+                g_error_free (error);
+
+        g_object_unref (task);
+}
+
+static void
+manager_request_name_owner (GvcMprisManager *manager,
+                            const gchar     *bus_name)
+{
+        GTask *task;
+
+        task = g_task_new (manager, NULL, NULL, NULL);
+        g_object_set_data_full (G_OBJECT (task), "gvc-bus-name", g_strdup (bus_name), g_free);
+        g_dbus_connection_call (manager->priv->connection,
+                                DBUS_NAME,
+                                DBUS_PATH,
+                                DBUS_IFACE,
+                                "GetNameOwner",
+                                g_variant_new ("(s)", bus_name),
+                                G_VARIANT_TYPE ("(s)"),
+                                G_DBUS_CALL_FLAGS_NONE,
+                                -1,
+                                NULL,
+                                on_get_name_owner_ready,
+                                task);
+}
+
+static void
+on_list_names_ready (GObject      *source_object,
+                     GAsyncResult *res,
+                     gpointer      user_data)
+{
+        GvcMprisManager *manager = GVC_MPRIS_MANAGER (user_data);
+        GVariant        *result;
+        GError          *error = NULL;
+        gchar          **names = NULL;
+        gint             i;
+
+        result = g_dbus_connection_call_finish (manager->priv->connection, res, &error);
+        if (result != NULL) {
+                g_variant_get (result, "(^as)", &names);
+                for (i = 0; names != NULL && names[i] != NULL; i++) {
+                        if (is_mpris_name (names[i]))
+                                manager_request_name_owner (manager, names[i]);
+                }
+                g_strfreev (names);
+                g_variant_unref (result);
+        }
+
+        if (error != NULL)
+                g_error_free (error);
+
+        g_object_unref (manager);
+}
+
+static void
+on_name_owner_changed (GDBusConnection *connection,
+                       const gchar     *sender_name,
+                       const gchar     *object_path,
+                       const gchar     *interface_name,
+                       const gchar     *signal_name,
+                       GVariant        *parameters,
+                       gpointer         user_data)
+{
+        GvcMprisManager *manager = GVC_MPRIS_MANAGER (user_data);
+        const gchar     *name;
+        const gchar     *old_owner;
+        const gchar     *new_owner;
+
+        g_variant_get (parameters, "(&s&s&s)", &name, &old_owner, &new_owner);
+
+        if (!is_mpris_name (name))
+                return;
+
+        if (new_owner[0] != '\0') {
+                if (old_owner[0] != '\0')
+                        manager_remove_player (manager, name);
+                manager_add_player (manager, name, new_owner);
+        } else if (old_owner[0] != '\0') {
+                manager_remove_player (manager, name);
+        }
+}
+
+static void
+on_bus_ready (GObject      *source_object,
+              GAsyncResult *res,
+              gpointer      user_data)
+{
+        GvcMprisManager *manager = GVC_MPRIS_MANAGER (user_data);
+        GError          *error = NULL;
+
+        manager->priv->connection = g_bus_get_finish (res, &error);
+        if (error != NULL) {
+                g_warning ("Unable to connect to the session bus for MPRIS: %s", error->message);
+                g_error_free (error);
+                g_object_unref (manager);
+                return;
+        }
+
+        manager->priv->name_owner_changed_id =
+                g_dbus_connection_signal_subscribe (manager->priv->connection,
+                                                    DBUS_NAME,
+                                                    DBUS_IFACE,
+                                                    "NameOwnerChanged",
+                                                    DBUS_PATH,
+                                                    NULL,
+                                                    G_DBUS_SIGNAL_FLAGS_NONE,
+                                                    on_name_owner_changed,
+                                                    manager,
+                                                    NULL);
+
+        g_dbus_connection_call (manager->priv->connection,
+                                DBUS_NAME,
+                                DBUS_PATH,
+                                DBUS_IFACE,
+                                "ListNames",
+                                NULL,
+                                G_VARIANT_TYPE ("(as)"),
+                                G_DBUS_CALL_FLAGS_NONE,
+                                -1,
+                                NULL,
+                                on_list_names_ready,
+                                g_object_ref (manager));
+
+        g_object_unref (manager);
+}
+
+static void
+gvc_mpris_manager_dispose (GObject *object)
+{
+        GvcMprisManager *manager = GVC_MPRIS_MANAGER (object);
+
+        if (manager->priv->connection != NULL &&
+            manager->priv->name_owner_changed_id != 0) {
+                g_dbus_connection_signal_unsubscribe (manager->priv->connection,
+                                                      manager->priv->name_owner_changed_id);
+                manager->priv->name_owner_changed_id = 0;
+        }
+
+        g_clear_object (&manager->priv->connection);
+        g_clear_pointer (&manager->priv->players, g_hash_table_unref);
+
+        G_OBJECT_CLASS (gvc_mpris_manager_parent_class)->dispose (object);
+}
+
+static void
+gvc_mpris_manager_class_init (GvcMprisManagerClass *klass)
+{
+        GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+        object_class->dispose = gvc_mpris_manager_dispose;
+
+        signals[PLAYER_ADDED] =
+                g_signal_new ("player-added",
+                              G_TYPE_FROM_CLASS (klass),
+                              G_SIGNAL_RUN_LAST,
+                              0, NULL, NULL, NULL,
+                              G_TYPE_NONE,
+                              1,
+                              GVC_TYPE_MPRIS_PLAYER);
+        signals[PLAYER_REMOVED] =
+                g_signal_new ("player-removed",
+                              G_TYPE_FROM_CLASS (klass),
+                              G_SIGNAL_RUN_LAST,
+                              0, NULL, NULL, NULL,
+                              G_TYPE_NONE,
+                              1,
+                              G_TYPE_STRING);
+}
+
+static void
+gvc_mpris_manager_init (GvcMprisManager *manager)
+{
+        manager->priv = gvc_mpris_manager_get_instance_private (manager);
+        manager->priv->players = g_hash_table_new_full (g_str_hash,
+                                                        g_str_equal,
+                                                        g_free,
+                                                        g_object_unref);
+}
+
+GvcMprisManager *
+gvc_mpris_manager_new (void)
+{
+        GvcMprisManager *manager;
+
+        manager = g_object_new (GVC_TYPE_MPRIS_MANAGER, NULL);
+        g_bus_get (G_BUS_TYPE_SESSION, NULL, on_bus_ready, g_object_ref (manager));
+
+        return manager;
+}
+
+GList *
+gvc_mpris_manager_get_players (GvcMprisManager *manager)
+{
+        g_return_val_if_fail (GVC_IS_MPRIS_MANAGER (manager), NULL);
+        return g_hash_table_get_values (manager->priv->players);
+}
+
+GvcMprisPlayer *
+gvc_mpris_manager_get_best_player (GvcMprisManager *manager)
+{
+        GHashTableIter iter;
+        gpointer       value;
+        GvcMprisPlayer *fallback = NULL;
+
+        g_return_val_if_fail (GVC_IS_MPRIS_MANAGER (manager), NULL);
+
+        g_hash_table_iter_init (&iter, manager->priv->players);
+        while (g_hash_table_iter_next (&iter, NULL, &value)) {
+                GvcMprisPlayer *player = value;
+
+                if (!gvc_mpris_player_is_ready (player))
+                        continue;
+
+                if (gvc_mpris_player_is_playing (player))
+                        return player;
+
+                if (fallback == NULL)
+                        fallback = player;
+        }
+
+        return fallback;
+}

--- a/mate-volume-control/gvc-mpris-manager.h
+++ b/mate-volume-control/gvc-mpris-manager.h
@@ -1,0 +1,39 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*- */
+
+#ifndef __GVC_MPRIS_MANAGER_H
+#define __GVC_MPRIS_MANAGER_H
+
+#include <gio/gio.h>
+#include <glib-object.h>
+
+#include "gvc-mpris-player.h"
+
+G_BEGIN_DECLS
+
+#define GVC_TYPE_MPRIS_MANAGER         (gvc_mpris_manager_get_type ())
+#define GVC_MPRIS_MANAGER(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), GVC_TYPE_MPRIS_MANAGER, GvcMprisManager))
+#define GVC_IS_MPRIS_MANAGER(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), GVC_TYPE_MPRIS_MANAGER))
+
+typedef struct _GvcMprisManager        GvcMprisManager;
+typedef struct _GvcMprisManagerClass   GvcMprisManagerClass;
+typedef struct _GvcMprisManagerPrivate GvcMprisManagerPrivate;
+
+struct _GvcMprisManager
+{
+        GObject                  parent;
+        GvcMprisManagerPrivate  *priv;
+};
+
+struct _GvcMprisManagerClass
+{
+        GObjectClass             parent_class;
+};
+
+GType            gvc_mpris_manager_get_type        (void) G_GNUC_CONST;
+GvcMprisManager *gvc_mpris_manager_new             (void);
+GList *          gvc_mpris_manager_get_players     (GvcMprisManager *manager);
+GvcMprisPlayer * gvc_mpris_manager_get_best_player (GvcMprisManager *manager);
+
+G_END_DECLS
+
+#endif /* __GVC_MPRIS_MANAGER_H */

--- a/mate-volume-control/gvc-mpris-player.c
+++ b/mate-volume-control/gvc-mpris-player.c
@@ -1,0 +1,687 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*- */
+
+#include "config.h"
+
+#include <string.h>
+#include <gio/gdesktopappinfo.h>
+#include <gdk/gdk.h>
+
+#include "gvc-mpris-player.h"
+
+#define MPRIS_OBJECT_PATH "/org/mpris/MediaPlayer2"
+#define MPRIS_SERVER_IFACE "org.mpris.MediaPlayer2"
+#define MPRIS_PLAYER_IFACE "org.mpris.MediaPlayer2.Player"
+#define DBUS_PROPERTIES_IFACE "org.freedesktop.DBus.Properties"
+
+struct _GvcMprisPlayerPrivate
+{
+        gchar      *bus_name;
+        gchar      *owner;
+        GDBusProxy *server_proxy;
+        GDBusProxy *player_proxy;
+        guint       pending_proxies;
+        gboolean    ready;
+
+        gchar      *identity;
+        gchar      *desktop_entry;
+        gchar      *playback_status;
+        gchar      *title;
+        gchar      *artist;
+        gchar      *album;
+        gchar      *art_url;
+        gchar      *track_id;
+        gchar      *loop_status;
+        gint64      length;
+
+        gboolean    can_raise;
+        gboolean    can_quit;
+        gboolean    can_control;
+        gboolean    can_play;
+        gboolean    can_pause;
+        gboolean    can_go_next;
+        gboolean    can_go_previous;
+        gboolean    can_seek;
+        gboolean    shuffle;
+};
+
+enum
+{
+        READY,
+        METADATA_CHANGED,
+        STATUS_CHANGED,
+        CAPABILITIES_CHANGED,
+        CLOSED,
+        N_SIGNALS
+};
+
+static guint signals[N_SIGNALS] = { 0 };
+
+G_DEFINE_TYPE_WITH_PRIVATE (GvcMprisPlayer, gvc_mpris_player, G_TYPE_OBJECT)
+
+static gchar *
+variant_dup_string (GVariant *variant)
+{
+        if (variant == NULL)
+                return g_strdup ("");
+
+        if (g_variant_is_of_type (variant, G_VARIANT_TYPE_STRING) ||
+            g_variant_is_of_type (variant, G_VARIANT_TYPE_OBJECT_PATH))
+                return g_variant_dup_string (variant, NULL);
+
+        if (g_variant_is_of_type (variant, G_VARIANT_TYPE_STRING_ARRAY)) {
+                const gchar **strv;
+                gchar        *joined;
+
+                strv = g_variant_get_strv (variant, NULL);
+                joined = g_strjoinv (", ", (gchar **) strv);
+                g_free (strv);
+                return joined;
+        }
+
+        return g_strdup ("");
+}
+
+static gboolean
+get_cached_boolean (GDBusProxy  *proxy,
+                    const gchar *name)
+{
+        GVariant *value;
+        gboolean  result = FALSE;
+
+        value = g_dbus_proxy_get_cached_property (proxy, name);
+        if (value != NULL) {
+                result = g_variant_get_boolean (value);
+                g_variant_unref (value);
+        }
+
+        return result;
+}
+
+static gchar *
+get_cached_string (GDBusProxy  *proxy,
+                   const gchar *name)
+{
+        GVariant *value;
+        gchar    *result = NULL;
+
+        value = g_dbus_proxy_get_cached_property (proxy, name);
+        if (value != NULL) {
+                result = variant_dup_string (value);
+                g_variant_unref (value);
+        }
+
+        return result;
+}
+
+static void
+gvc_mpris_player_update_metadata (GvcMprisPlayer *player,
+                                  GVariant       *metadata)
+{
+        GVariantIter iter;
+        const gchar *key;
+        GVariant    *value;
+
+        if (metadata == NULL)
+                return;
+
+        g_clear_pointer (&player->priv->title, g_free);
+        g_clear_pointer (&player->priv->artist, g_free);
+        g_clear_pointer (&player->priv->album, g_free);
+        g_clear_pointer (&player->priv->art_url, g_free);
+        g_clear_pointer (&player->priv->track_id, g_free);
+        player->priv->length = 0;
+
+        player->priv->title = g_strdup ("");
+        player->priv->artist = g_strdup ("");
+        player->priv->album = g_strdup ("");
+        player->priv->art_url = g_strdup ("");
+        player->priv->track_id = g_strdup ("");
+
+        g_variant_iter_init (&iter, metadata);
+        while (g_variant_iter_next (&iter, "{&sv}", &key, &value)) {
+                if (g_str_equal (key, "xesam:title")) {
+                        g_free (player->priv->title);
+                        player->priv->title = variant_dup_string (value);
+                } else if (g_str_equal (key, "xesam:artist")) {
+                        g_free (player->priv->artist);
+                        player->priv->artist = variant_dup_string (value);
+                } else if (g_str_equal (key, "xesam:album")) {
+                        g_free (player->priv->album);
+                        player->priv->album = variant_dup_string (value);
+                } else if (g_str_equal (key, "mpris:artUrl")) {
+                        g_free (player->priv->art_url);
+                        player->priv->art_url = variant_dup_string (value);
+                } else if (g_str_equal (key, "mpris:trackid")) {
+                        g_free (player->priv->track_id);
+                        player->priv->track_id = variant_dup_string (value);
+                } else if (g_str_equal (key, "mpris:length")) {
+                        player->priv->length = g_variant_get_int64 (value);
+                }
+
+                g_variant_unref (value);
+        }
+}
+
+static void
+gvc_mpris_player_update_capabilities (GvcMprisPlayer *player)
+{
+        if (player->priv->server_proxy != NULL) {
+                player->priv->can_raise = get_cached_boolean (player->priv->server_proxy, "CanRaise");
+                player->priv->can_quit = get_cached_boolean (player->priv->server_proxy, "CanQuit");
+        }
+
+        if (player->priv->player_proxy != NULL) {
+                player->priv->can_control = get_cached_boolean (player->priv->player_proxy, "CanControl");
+                player->priv->can_play = get_cached_boolean (player->priv->player_proxy, "CanPlay");
+                player->priv->can_pause = get_cached_boolean (player->priv->player_proxy, "CanPause");
+                player->priv->can_go_next = get_cached_boolean (player->priv->player_proxy, "CanGoNext");
+                player->priv->can_go_previous = get_cached_boolean (player->priv->player_proxy, "CanGoPrevious");
+                player->priv->can_seek = get_cached_boolean (player->priv->player_proxy, "CanSeek");
+        }
+}
+
+static void
+gvc_mpris_player_read_initial_state (GvcMprisPlayer *player)
+{
+        GVariant *metadata;
+        gchar    *value;
+
+        value = get_cached_string (player->priv->server_proxy, "Identity");
+        if (value != NULL && value[0] != '\0') {
+                g_free (player->priv->identity);
+                player->priv->identity = value;
+        } else {
+                gchar *name = g_strdup (player->priv->bus_name + strlen ("org.mpris.MediaPlayer2."));
+                g_free (value);
+                if (name[0] != '\0')
+                        name[0] = g_ascii_toupper (name[0]);
+                g_free (player->priv->identity);
+                player->priv->identity = name;
+        }
+
+        g_free (player->priv->desktop_entry);
+        player->priv->desktop_entry = get_cached_string (player->priv->server_proxy, "DesktopEntry");
+
+        g_free (player->priv->playback_status);
+        player->priv->playback_status = get_cached_string (player->priv->player_proxy, "PlaybackStatus");
+        if (player->priv->playback_status == NULL || player->priv->playback_status[0] == '\0') {
+                g_free (player->priv->playback_status);
+                player->priv->playback_status = g_strdup ("Unknown");
+        }
+
+        g_free (player->priv->loop_status);
+        player->priv->loop_status = get_cached_string (player->priv->player_proxy, "LoopStatus");
+        if (player->priv->loop_status == NULL)
+                player->priv->loop_status = g_strdup ("None");
+
+        player->priv->shuffle = get_cached_boolean (player->priv->player_proxy, "Shuffle");
+
+        metadata = g_dbus_proxy_get_cached_property (player->priv->player_proxy, "Metadata");
+        gvc_mpris_player_update_metadata (player, metadata);
+        if (metadata != NULL)
+                g_variant_unref (metadata);
+
+        gvc_mpris_player_update_capabilities (player);
+}
+
+static void
+on_proxy_properties_changed (GDBusProxy     *proxy,
+                             GVariant       *changed_properties,
+                             const gchar   **invalidated_properties,
+                             GvcMprisPlayer *player)
+{
+        gboolean metadata_changed = FALSE;
+        gboolean status_changed = FALSE;
+        gboolean capabilities_changed = FALSE;
+        gboolean player_iface;
+        GVariantIter iter;
+        const gchar *key;
+        GVariant    *value;
+
+        player_iface = proxy == player->priv->player_proxy;
+
+        g_variant_iter_init (&iter, changed_properties);
+        while (g_variant_iter_next (&iter, "{&sv}", &key, &value)) {
+                if (player_iface && g_str_equal (key, "Metadata")) {
+                        gvc_mpris_player_update_metadata (player, value);
+                        metadata_changed = TRUE;
+                } else if (player_iface && g_str_equal (key, "PlaybackStatus")) {
+                        g_free (player->priv->playback_status);
+                        player->priv->playback_status = variant_dup_string (value);
+                        status_changed = TRUE;
+                } else if (player_iface && g_str_equal (key, "Shuffle")) {
+                        player->priv->shuffle = g_variant_get_boolean (value);
+                        capabilities_changed = TRUE;
+                } else if (player_iface && g_str_equal (key, "LoopStatus")) {
+                        g_free (player->priv->loop_status);
+                        player->priv->loop_status = variant_dup_string (value);
+                        capabilities_changed = TRUE;
+                } else if (!player_iface && g_str_equal (key, "Identity")) {
+                        g_free (player->priv->identity);
+                        player->priv->identity = variant_dup_string (value);
+                        metadata_changed = TRUE;
+                } else if (!player_iface && g_str_equal (key, "DesktopEntry")) {
+                        g_free (player->priv->desktop_entry);
+                        player->priv->desktop_entry = variant_dup_string (value);
+                } else if (g_str_has_prefix (key, "Can")) {
+                        capabilities_changed = TRUE;
+                }
+
+                g_variant_unref (value);
+        }
+
+        if (capabilities_changed) {
+                gvc_mpris_player_update_capabilities (player);
+                g_signal_emit (player, signals[CAPABILITIES_CHANGED], 0);
+        }
+        if (metadata_changed)
+                g_signal_emit (player, signals[METADATA_CHANGED], 0);
+        if (status_changed)
+                g_signal_emit (player, signals[STATUS_CHANGED], 0);
+}
+
+static void
+on_proxy_ready (GObject      *source_object,
+                GAsyncResult *res,
+                gpointer      user_data)
+{
+        GvcMprisPlayer *player = GVC_MPRIS_PLAYER (user_data);
+        GDBusProxy     *proxy;
+        GError         *error = NULL;
+
+        proxy = g_dbus_proxy_new_for_bus_finish (res, &error);
+        if (error != NULL) {
+                g_debug ("Unable to create MPRIS proxy for %s: %s",
+                         player->priv->bus_name,
+                         error->message);
+                g_error_free (error);
+        } else if (g_str_equal (g_dbus_proxy_get_interface_name (proxy), MPRIS_SERVER_IFACE)) {
+                player->priv->server_proxy = proxy;
+                g_signal_connect (proxy,
+                                  "g-properties-changed",
+                                  G_CALLBACK (on_proxy_properties_changed),
+                                  player);
+        } else {
+                player->priv->player_proxy = proxy;
+                g_signal_connect (proxy,
+                                  "g-properties-changed",
+                                  G_CALLBACK (on_proxy_properties_changed),
+                                  player);
+        }
+
+        player->priv->pending_proxies--;
+
+        if (player->priv->pending_proxies == 0 &&
+            player->priv->server_proxy != NULL &&
+            player->priv->player_proxy != NULL) {
+                gvc_mpris_player_read_initial_state (player);
+                player->priv->ready = TRUE;
+                g_signal_emit (player, signals[READY], 0);
+        }
+
+        g_object_unref (player);
+}
+
+static void
+gvc_mpris_player_call (GvcMprisPlayer *player,
+                       GDBusProxy     *proxy,
+                       const gchar    *method,
+                       GVariant       *parameters)
+{
+        if (proxy == NULL)
+                return;
+
+        g_dbus_proxy_call (proxy,
+                           method,
+                           parameters,
+                           G_DBUS_CALL_FLAGS_NONE,
+                           -1,
+                           NULL,
+                           NULL,
+                           NULL);
+}
+
+static gboolean
+gvc_mpris_player_launch_desktop_entry (GvcMprisPlayer *player)
+{
+        GDesktopAppInfo *app_info;
+        GdkDisplay      *display;
+        GdkAppLaunchContext *context = NULL;
+        GError          *error = NULL;
+        gboolean         launched = FALSE;
+
+        if (player->priv->desktop_entry == NULL ||
+            player->priv->desktop_entry[0] == '\0')
+                return FALSE;
+
+        app_info = g_desktop_app_info_new (player->priv->desktop_entry);
+        if (app_info == NULL && !g_str_has_suffix (player->priv->desktop_entry, ".desktop")) {
+                gchar *desktop_id;
+
+                desktop_id = g_strconcat (player->priv->desktop_entry, ".desktop", NULL);
+                app_info = g_desktop_app_info_new (desktop_id);
+                g_free (desktop_id);
+        }
+
+        if (app_info == NULL)
+                return FALSE;
+
+        display = gdk_display_get_default ();
+        if (display != NULL) {
+                context = gdk_display_get_app_launch_context (display);
+                gdk_app_launch_context_set_timestamp (context, GDK_CURRENT_TIME);
+        }
+
+        launched = g_app_info_launch (G_APP_INFO (app_info),
+                                      NULL,
+                                      context != NULL ? G_APP_LAUNCH_CONTEXT (context) : NULL,
+                                      &error);
+        if (error != NULL)
+                g_error_free (error);
+
+        if (context != NULL)
+                g_object_unref (context);
+        g_object_unref (app_info);
+
+        return launched;
+}
+
+static void
+gvc_mpris_player_set_property_variant (GvcMprisPlayer *player,
+                                       const gchar    *property,
+                                       GVariant       *value)
+{
+        GDBusConnection *connection;
+
+        if (player->priv->player_proxy == NULL)
+                return;
+
+        connection = g_dbus_proxy_get_connection (player->priv->player_proxy);
+        g_dbus_connection_call (connection,
+                                player->priv->bus_name,
+                                MPRIS_OBJECT_PATH,
+                                DBUS_PROPERTIES_IFACE,
+                                "Set",
+                                g_variant_new ("(ssv)", MPRIS_PLAYER_IFACE, property, value),
+                                NULL,
+                                G_DBUS_CALL_FLAGS_NONE,
+                                -1,
+                                NULL,
+                                NULL,
+                                NULL);
+}
+
+static void
+gvc_mpris_player_dispose (GObject *object)
+{
+        GvcMprisPlayer *player = GVC_MPRIS_PLAYER (object);
+
+        g_clear_object (&player->priv->server_proxy);
+        g_clear_object (&player->priv->player_proxy);
+
+        G_OBJECT_CLASS (gvc_mpris_player_parent_class)->dispose (object);
+}
+
+static void
+gvc_mpris_player_finalize (GObject *object)
+{
+        GvcMprisPlayer *player = GVC_MPRIS_PLAYER (object);
+
+        g_clear_pointer (&player->priv->bus_name, g_free);
+        g_clear_pointer (&player->priv->owner, g_free);
+        g_clear_pointer (&player->priv->identity, g_free);
+        g_clear_pointer (&player->priv->desktop_entry, g_free);
+        g_clear_pointer (&player->priv->playback_status, g_free);
+        g_clear_pointer (&player->priv->title, g_free);
+        g_clear_pointer (&player->priv->artist, g_free);
+        g_clear_pointer (&player->priv->album, g_free);
+        g_clear_pointer (&player->priv->art_url, g_free);
+        g_clear_pointer (&player->priv->track_id, g_free);
+        g_clear_pointer (&player->priv->loop_status, g_free);
+
+        G_OBJECT_CLASS (gvc_mpris_player_parent_class)->finalize (object);
+}
+
+static void
+gvc_mpris_player_class_init (GvcMprisPlayerClass *klass)
+{
+        GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+        object_class->dispose = gvc_mpris_player_dispose;
+        object_class->finalize = gvc_mpris_player_finalize;
+
+        signals[READY] =
+                g_signal_new ("ready",
+                              G_TYPE_FROM_CLASS (klass),
+                              G_SIGNAL_RUN_LAST,
+                              0, NULL, NULL, NULL,
+                              G_TYPE_NONE,
+                              0);
+        signals[METADATA_CHANGED] =
+                g_signal_new ("metadata-changed",
+                              G_TYPE_FROM_CLASS (klass),
+                              G_SIGNAL_RUN_LAST,
+                              0, NULL, NULL, NULL,
+                              G_TYPE_NONE,
+                              0);
+        signals[STATUS_CHANGED] =
+                g_signal_new ("status-changed",
+                              G_TYPE_FROM_CLASS (klass),
+                              G_SIGNAL_RUN_LAST,
+                              0, NULL, NULL, NULL,
+                              G_TYPE_NONE,
+                              0);
+        signals[CAPABILITIES_CHANGED] =
+                g_signal_new ("capabilities-changed",
+                              G_TYPE_FROM_CLASS (klass),
+                              G_SIGNAL_RUN_LAST,
+                              0, NULL, NULL, NULL,
+                              G_TYPE_NONE,
+                              0);
+        signals[CLOSED] =
+                g_signal_new ("closed",
+                              G_TYPE_FROM_CLASS (klass),
+                              G_SIGNAL_RUN_LAST,
+                              0, NULL, NULL, NULL,
+                              G_TYPE_NONE,
+                              0);
+}
+
+static void
+gvc_mpris_player_init (GvcMprisPlayer *player)
+{
+        player->priv = gvc_mpris_player_get_instance_private (player);
+        player->priv->pending_proxies = 2;
+        player->priv->playback_status = g_strdup ("Unknown");
+        player->priv->title = g_strdup ("");
+        player->priv->artist = g_strdup ("");
+        player->priv->album = g_strdup ("");
+        player->priv->art_url = g_strdup ("");
+        player->priv->track_id = g_strdup ("");
+        player->priv->loop_status = g_strdup ("None");
+}
+
+GvcMprisPlayer *
+gvc_mpris_player_new (const gchar *bus_name,
+                      const gchar *owner)
+{
+        GvcMprisPlayer *player;
+
+        g_return_val_if_fail (bus_name != NULL, NULL);
+        g_return_val_if_fail (owner != NULL, NULL);
+
+        player = g_object_new (GVC_TYPE_MPRIS_PLAYER, NULL);
+        player->priv->bus_name = g_strdup (bus_name);
+        player->priv->owner = g_strdup (owner);
+
+        g_dbus_proxy_new_for_bus (G_BUS_TYPE_SESSION,
+                                  G_DBUS_PROXY_FLAGS_NONE,
+                                  NULL,
+                                  bus_name,
+                                  MPRIS_OBJECT_PATH,
+                                  MPRIS_SERVER_IFACE,
+                                  NULL,
+                                  on_proxy_ready,
+                                  g_object_ref (player));
+        g_dbus_proxy_new_for_bus (G_BUS_TYPE_SESSION,
+                                  G_DBUS_PROXY_FLAGS_NONE,
+                                  NULL,
+                                  bus_name,
+                                  MPRIS_OBJECT_PATH,
+                                  MPRIS_PLAYER_IFACE,
+                                  NULL,
+                                  on_proxy_ready,
+                                  g_object_ref (player));
+
+        return player;
+}
+
+const gchar *
+gvc_mpris_player_get_bus_name (GvcMprisPlayer *player)
+{
+        g_return_val_if_fail (GVC_IS_MPRIS_PLAYER (player), NULL);
+        return player->priv->bus_name;
+}
+
+const gchar *
+gvc_mpris_player_get_owner (GvcMprisPlayer *player)
+{
+        g_return_val_if_fail (GVC_IS_MPRIS_PLAYER (player), NULL);
+        return player->priv->owner;
+}
+
+gboolean
+gvc_mpris_player_is_ready (GvcMprisPlayer *player)
+{
+        g_return_val_if_fail (GVC_IS_MPRIS_PLAYER (player), FALSE);
+        return player->priv->ready;
+}
+
+gboolean
+gvc_mpris_player_is_playing (GvcMprisPlayer *player)
+{
+        g_return_val_if_fail (GVC_IS_MPRIS_PLAYER (player), FALSE);
+        return g_strcmp0 (player->priv->playback_status, "Playing") == 0;
+}
+
+const gchar * gvc_mpris_player_get_identity (GvcMprisPlayer *player) { return player->priv->identity ? player->priv->identity : ""; }
+const gchar * gvc_mpris_player_get_desktop_entry (GvcMprisPlayer *player) { return player->priv->desktop_entry ? player->priv->desktop_entry : ""; }
+const gchar * gvc_mpris_player_get_playback_status (GvcMprisPlayer *player) { return player->priv->playback_status ? player->priv->playback_status : "Unknown"; }
+const gchar * gvc_mpris_player_get_title (GvcMprisPlayer *player) { return player->priv->title ? player->priv->title : ""; }
+const gchar * gvc_mpris_player_get_artist (GvcMprisPlayer *player) { return player->priv->artist ? player->priv->artist : ""; }
+const gchar * gvc_mpris_player_get_album (GvcMprisPlayer *player) { return player->priv->album ? player->priv->album : ""; }
+const gchar * gvc_mpris_player_get_art_url (GvcMprisPlayer *player) { return player->priv->art_url ? player->priv->art_url : ""; }
+const gchar * gvc_mpris_player_get_track_id (GvcMprisPlayer *player) { return player->priv->track_id ? player->priv->track_id : ""; }
+gint64 gvc_mpris_player_get_length (GvcMprisPlayer *player) { return player->priv->length; }
+gboolean gvc_mpris_player_get_can_go_next (GvcMprisPlayer *player) { return player->priv->can_go_next; }
+gboolean gvc_mpris_player_get_can_go_previous (GvcMprisPlayer *player) { return player->priv->can_go_previous; }
+gboolean gvc_mpris_player_get_can_play (GvcMprisPlayer *player) { return player->priv->can_play; }
+gboolean gvc_mpris_player_get_can_pause (GvcMprisPlayer *player) { return player->priv->can_pause; }
+gboolean gvc_mpris_player_get_can_seek (GvcMprisPlayer *player) { return player->priv->can_seek; }
+gboolean gvc_mpris_player_get_can_raise (GvcMprisPlayer *player) { return player->priv->can_raise || (player->priv->desktop_entry != NULL && player->priv->desktop_entry[0] != '\0') || (player->priv->identity != NULL && g_ascii_strcasecmp (player->priv->identity, "spotify") == 0); }
+gboolean gvc_mpris_player_get_can_quit (GvcMprisPlayer *player) { return player->priv->can_quit; }
+gboolean gvc_mpris_player_get_shuffle (GvcMprisPlayer *player) { return player->priv->shuffle; }
+const gchar * gvc_mpris_player_get_loop_status (GvcMprisPlayer *player) { return player->priv->loop_status ? player->priv->loop_status : "None"; }
+
+void gvc_mpris_player_play_pause (GvcMprisPlayer *player) { gvc_mpris_player_call (player, player->priv->player_proxy, "PlayPause", NULL); }
+void gvc_mpris_player_stop (GvcMprisPlayer *player) { gvc_mpris_player_call (player, player->priv->player_proxy, "Stop", NULL); }
+void gvc_mpris_player_next (GvcMprisPlayer *player) { if (player->priv->can_go_next) gvc_mpris_player_call (player, player->priv->player_proxy, "Next", NULL); }
+void gvc_mpris_player_previous (GvcMprisPlayer *player) { if (player->priv->can_go_previous) gvc_mpris_player_call (player, player->priv->player_proxy, "Previous", NULL); }
+void
+gvc_mpris_player_raise (GvcMprisPlayer *player)
+{
+        if (player->priv->identity != NULL &&
+            g_ascii_strcasecmp (player->priv->identity, "spotify") == 0) {
+                gchar *argv[] = { "spotify", NULL };
+                g_spawn_async (NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL);
+                return;
+        }
+
+        if (player->priv->can_raise)
+                gvc_mpris_player_call (player, player->priv->server_proxy, "Raise", NULL);
+
+        gvc_mpris_player_launch_desktop_entry (player);
+}
+void gvc_mpris_player_quit (GvcMprisPlayer *player) { if (player->priv->can_quit) gvc_mpris_player_call (player, player->priv->server_proxy, "Quit", NULL); }
+void gvc_mpris_player_set_shuffle (GvcMprisPlayer *player, gboolean shuffle) { gvc_mpris_player_set_property_variant (player, "Shuffle", g_variant_new_boolean (shuffle)); }
+void gvc_mpris_player_set_loop_status (GvcMprisPlayer *player, const gchar *loop_status) { gvc_mpris_player_set_property_variant (player, "LoopStatus", g_variant_new_string (loop_status)); }
+
+void
+gvc_mpris_player_set_position (GvcMprisPlayer *player,
+                               const gchar    *track_id,
+                               gint64          position)
+{
+        if (!player->priv->can_seek || track_id == NULL || track_id[0] == '\0')
+                return;
+
+        gvc_mpris_player_call (player,
+                               player->priv->player_proxy,
+                               "SetPosition",
+                               g_variant_new ("(ox)", track_id, position));
+}
+
+typedef struct
+{
+        GvcMprisPlayer          *player;
+        GvcMprisPositionCallback callback;
+        gpointer                 user_data;
+} PositionData;
+
+static void
+on_get_position_ready (GObject      *source_object,
+                       GAsyncResult *res,
+                       gpointer      user_data)
+{
+        PositionData   *data = user_data;
+        GVariant       *result;
+        GVariant       *value = NULL;
+        GError         *error = NULL;
+        gint64          position = 0;
+
+        result = g_dbus_connection_call_finish (G_DBUS_CONNECTION (source_object), res, &error);
+        if (result != NULL) {
+                g_variant_get (result, "(v)", &value);
+                position = g_variant_get_int64 (value);
+                g_variant_unref (value);
+                g_variant_unref (result);
+        }
+
+        if (data->callback != NULL)
+                data->callback (data->player, position, error, data->user_data);
+
+        if (error != NULL)
+                g_error_free (error);
+        g_object_unref (data->player);
+        g_free (data);
+}
+
+void
+gvc_mpris_player_get_position_async (GvcMprisPlayer          *player,
+                                     GvcMprisPositionCallback callback,
+                                     gpointer                 user_data)
+{
+        PositionData *data;
+
+        g_return_if_fail (GVC_IS_MPRIS_PLAYER (player));
+
+        if (player->priv->player_proxy == NULL || !player->priv->can_seek)
+                return;
+
+        data = g_new0 (PositionData, 1);
+        data->player = g_object_ref (player);
+        data->callback = callback;
+        data->user_data = user_data;
+
+        g_dbus_connection_call (g_dbus_proxy_get_connection (player->priv->player_proxy),
+                                player->priv->bus_name,
+                                MPRIS_OBJECT_PATH,
+                                DBUS_PROPERTIES_IFACE,
+                                "Get",
+                                g_variant_new ("(ss)", MPRIS_PLAYER_IFACE, "Position"),
+                                G_VARIANT_TYPE ("(v)"),
+                                G_DBUS_CALL_FLAGS_NONE,
+                                -1,
+                                NULL,
+                                on_get_position_ready,
+                                data);
+}

--- a/mate-volume-control/gvc-mpris-player.h
+++ b/mate-volume-control/gvc-mpris-player.h
@@ -1,0 +1,86 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*- */
+
+#ifndef __GVC_MPRIS_PLAYER_H
+#define __GVC_MPRIS_PLAYER_H
+
+#include <gio/gio.h>
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define GVC_TYPE_MPRIS_PLAYER         (gvc_mpris_player_get_type ())
+#define GVC_MPRIS_PLAYER(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), GVC_TYPE_MPRIS_PLAYER, GvcMprisPlayer))
+#define GVC_MPRIS_PLAYER_CLASS(k)     (G_TYPE_CHECK_CLASS_CAST ((k), GVC_TYPE_MPRIS_PLAYER, GvcMprisPlayerClass))
+#define GVC_IS_MPRIS_PLAYER(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), GVC_TYPE_MPRIS_PLAYER))
+#define GVC_IS_MPRIS_PLAYER_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), GVC_TYPE_MPRIS_PLAYER))
+#define GVC_MPRIS_PLAYER_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), GVC_TYPE_MPRIS_PLAYER, GvcMprisPlayerClass))
+
+typedef struct _GvcMprisPlayer        GvcMprisPlayer;
+typedef struct _GvcMprisPlayerClass   GvcMprisPlayerClass;
+typedef struct _GvcMprisPlayerPrivate GvcMprisPlayerPrivate;
+
+struct _GvcMprisPlayer
+{
+        GObject                 parent;
+        GvcMprisPlayerPrivate  *priv;
+};
+
+struct _GvcMprisPlayerClass
+{
+        GObjectClass            parent_class;
+};
+
+typedef void (*GvcMprisPositionCallback) (GvcMprisPlayer *player,
+                                          gint64          position,
+                                          GError         *error,
+                                          gpointer        user_data);
+
+GType            gvc_mpris_player_get_type              (void) G_GNUC_CONST;
+GvcMprisPlayer * gvc_mpris_player_new                   (const gchar *bus_name,
+                                                         const gchar *owner);
+
+const gchar *    gvc_mpris_player_get_bus_name          (GvcMprisPlayer *player);
+const gchar *    gvc_mpris_player_get_owner             (GvcMprisPlayer *player);
+gboolean         gvc_mpris_player_is_ready              (GvcMprisPlayer *player);
+gboolean         gvc_mpris_player_is_playing            (GvcMprisPlayer *player);
+
+const gchar *    gvc_mpris_player_get_identity          (GvcMprisPlayer *player);
+const gchar *    gvc_mpris_player_get_desktop_entry     (GvcMprisPlayer *player);
+const gchar *    gvc_mpris_player_get_playback_status   (GvcMprisPlayer *player);
+const gchar *    gvc_mpris_player_get_title             (GvcMprisPlayer *player);
+const gchar *    gvc_mpris_player_get_artist            (GvcMprisPlayer *player);
+const gchar *    gvc_mpris_player_get_album             (GvcMprisPlayer *player);
+const gchar *    gvc_mpris_player_get_art_url           (GvcMprisPlayer *player);
+const gchar *    gvc_mpris_player_get_track_id          (GvcMprisPlayer *player);
+gint64           gvc_mpris_player_get_length            (GvcMprisPlayer *player);
+
+gboolean         gvc_mpris_player_get_can_go_next       (GvcMprisPlayer *player);
+gboolean         gvc_mpris_player_get_can_go_previous   (GvcMprisPlayer *player);
+gboolean         gvc_mpris_player_get_can_play          (GvcMprisPlayer *player);
+gboolean         gvc_mpris_player_get_can_pause         (GvcMprisPlayer *player);
+gboolean         gvc_mpris_player_get_can_seek          (GvcMprisPlayer *player);
+gboolean         gvc_mpris_player_get_can_raise         (GvcMprisPlayer *player);
+gboolean         gvc_mpris_player_get_can_quit          (GvcMprisPlayer *player);
+gboolean         gvc_mpris_player_get_shuffle           (GvcMprisPlayer *player);
+const gchar *    gvc_mpris_player_get_loop_status       (GvcMprisPlayer *player);
+
+void             gvc_mpris_player_play_pause            (GvcMprisPlayer *player);
+void             gvc_mpris_player_stop                  (GvcMprisPlayer *player);
+void             gvc_mpris_player_next                  (GvcMprisPlayer *player);
+void             gvc_mpris_player_previous              (GvcMprisPlayer *player);
+void             gvc_mpris_player_set_position          (GvcMprisPlayer *player,
+                                                         const gchar    *track_id,
+                                                         gint64          position);
+void             gvc_mpris_player_raise                 (GvcMprisPlayer *player);
+void             gvc_mpris_player_quit                  (GvcMprisPlayer *player);
+void             gvc_mpris_player_set_shuffle           (GvcMprisPlayer *player,
+                                                         gboolean        shuffle);
+void             gvc_mpris_player_set_loop_status       (GvcMprisPlayer *player,
+                                                         const gchar    *loop_status);
+void             gvc_mpris_player_get_position_async    (GvcMprisPlayer          *player,
+                                                         GvcMprisPositionCallback callback,
+                                                         gpointer                 user_data);
+
+G_END_DECLS
+
+#endif /* __GVC_MPRIS_PLAYER_H */

--- a/mate-volume-control/gvc-player-widget.c
+++ b/mate-volume-control/gvc-player-widget.c
@@ -1,0 +1,826 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*- */
+
+#include "config.h"
+
+#include <string.h>
+#include <glib/gi18n-lib.h>
+
+#include "gvc-player-widget.h"
+
+#define COVER_SIZE 300
+#define PLAYER_WIDTH 316
+
+struct _GvcPlayerWidgetPrivate
+{
+        GvcMprisPlayer *player;
+        GtkImage       *cover;
+        GtkLabel       *player_label;
+        GtkComboBox    *player_combo;
+        GtkLabel       *title_label;
+        GtkLabel       *artist_label;
+        GtkButton      *prev_button;
+        GtkButton      *play_button;
+        GtkButton      *stop_button;
+        GtkButton      *next_button;
+        GtkButton      *raise_button;
+        GtkButton      *quit_button;
+        GtkToggleButton *shuffle_button;
+        GtkButton      *loop_button;
+        GtkScale       *seek_scale;
+        GtkLabel       *time_label;
+        guint           seek_timer_id;
+        gboolean        updating_seek;
+        gboolean        updating_players;
+};
+
+enum
+{
+        PLAYER_SELECTED,
+        N_SIGNALS
+};
+
+enum
+{
+        PLAYER_COLUMN_LABEL,
+        PLAYER_COLUMN_PLAYER,
+        N_PLAYER_COLUMNS
+};
+
+static guint signals[N_SIGNALS] = { 0 };
+
+G_DEFINE_TYPE_WITH_PRIVATE (GvcPlayerWidget, gvc_player_widget, GTK_TYPE_BOX)
+
+static gchar *
+format_time (gint64 seconds)
+{
+        gint64 minutes;
+
+        if (seconds < 0)
+                seconds = 0;
+
+        minutes = seconds / 60;
+        seconds = seconds % 60;
+
+        return g_strdup_printf ("%" G_GINT64_FORMAT ":%02" G_GINT64_FORMAT, minutes, seconds);
+}
+
+static void
+set_cover_fallback (GvcPlayerWidget *widget)
+{
+        gtk_image_set_from_icon_name (widget->priv->cover,
+                                      "media-optical",
+                                      GTK_ICON_SIZE_DIALOG);
+        gtk_image_set_pixel_size (widget->priv->cover, COVER_SIZE);
+}
+
+static void
+on_cover_pixbuf_ready (GObject      *source_object,
+                       GAsyncResult *res,
+                       gpointer      user_data)
+{
+        GvcPlayerWidget *widget = GVC_PLAYER_WIDGET (user_data);
+        GdkPixbuf       *pixbuf;
+        GError          *error = NULL;
+
+        pixbuf = gdk_pixbuf_new_from_stream_finish (res, &error);
+        if (pixbuf != NULL) {
+                gtk_image_set_from_pixbuf (widget->priv->cover, pixbuf);
+                g_object_unref (pixbuf);
+        } else {
+                set_cover_fallback (widget);
+                if (error != NULL)
+                        g_error_free (error);
+        }
+
+        g_object_unref (widget);
+}
+
+static void
+load_cover_from_stream (GvcPlayerWidget *widget,
+                        GInputStream    *stream)
+{
+        gdk_pixbuf_new_from_stream_at_scale_async (stream,
+                                                   COVER_SIZE,
+                                                   COVER_SIZE,
+                                                   TRUE,
+                                                   NULL,
+                                                   on_cover_pixbuf_ready,
+                                                   g_object_ref (widget));
+}
+
+static void
+on_cover_file_read_ready (GObject      *source_object,
+                          GAsyncResult *res,
+                          gpointer      user_data)
+{
+        GvcPlayerWidget *widget = GVC_PLAYER_WIDGET (user_data);
+        GInputStream    *stream;
+        GError          *error = NULL;
+
+        stream = G_INPUT_STREAM (g_file_read_finish (G_FILE (source_object), res, &error));
+        if (stream != NULL) {
+                load_cover_from_stream (widget, stream);
+                g_object_unref (stream);
+        } else {
+                set_cover_fallback (widget);
+                if (error != NULL)
+                        g_error_free (error);
+        }
+
+        g_object_unref (widget);
+}
+
+static void
+update_cover (GvcPlayerWidget *widget)
+{
+        const gchar *art_url;
+
+        art_url = gvc_mpris_player_get_art_url (widget->priv->player);
+        if (art_url == NULL || art_url[0] == '\0') {
+                set_cover_fallback (widget);
+                return;
+        }
+
+        if (g_str_has_prefix (art_url, "data:image/")) {
+                const gchar *comma;
+
+                comma = strchr (art_url, ',');
+                if (comma != NULL) {
+                        guchar       *decoded;
+                        gsize         len;
+                        GInputStream *stream;
+
+                        decoded = g_base64_decode (comma + 1, &len);
+                        stream = g_memory_input_stream_new_from_data (decoded, len, g_free);
+                        load_cover_from_stream (widget, stream);
+                        g_object_unref (stream);
+                        return;
+                }
+        } else {
+                GFile *file;
+
+                file = g_file_new_for_uri (art_url);
+                g_file_read_async (file,
+                                   G_PRIORITY_DEFAULT,
+                                   NULL,
+                                   on_cover_file_read_ready,
+                                   g_object_ref (widget));
+                g_object_unref (file);
+                return;
+        }
+
+        set_cover_fallback (widget);
+}
+
+static void
+on_position_ready (GvcMprisPlayer *player,
+                   gint64          position,
+                   GError         *error,
+                   gpointer        user_data)
+{
+        GvcPlayerWidget *widget = GVC_PLAYER_WIDGET (user_data);
+        gint64           length;
+        gchar           *elapsed;
+        gchar           *total;
+        gchar           *label;
+
+        if (error != NULL || widget->priv->player != player) {
+                g_object_unref (widget);
+                return;
+        }
+
+        length = gvc_mpris_player_get_length (player) / G_USEC_PER_SEC;
+        position = position / G_USEC_PER_SEC;
+
+        widget->priv->updating_seek = TRUE;
+        gtk_range_set_value (GTK_RANGE (widget->priv->seek_scale), position);
+        widget->priv->updating_seek = FALSE;
+
+        elapsed = format_time (position);
+        total = format_time (length);
+        label = g_strdup_printf ("%s / %s", elapsed, total);
+        gtk_label_set_text (widget->priv->time_label, label);
+        g_free (elapsed);
+        g_free (total);
+        g_free (label);
+        g_object_unref (widget);
+}
+
+static gboolean
+seek_timer_cb (gpointer user_data)
+{
+        GvcPlayerWidget *widget = GVC_PLAYER_WIDGET (user_data);
+
+        if (widget->priv->player == NULL ||
+            !gvc_mpris_player_is_playing (widget->priv->player) ||
+            !gvc_mpris_player_get_can_seek (widget->priv->player)) {
+                widget->priv->seek_timer_id = 0;
+                return G_SOURCE_REMOVE;
+        }
+
+        gvc_mpris_player_get_position_async (widget->priv->player,
+                                             on_position_ready,
+                                             g_object_ref (widget));
+        return G_SOURCE_CONTINUE;
+}
+
+static void
+ensure_seek_timer (GvcPlayerWidget *widget)
+{
+        if (widget->priv->seek_timer_id != 0)
+                g_source_remove (widget->priv->seek_timer_id);
+
+        widget->priv->seek_timer_id = 0;
+
+        if (widget->priv->player != NULL &&
+            gvc_mpris_player_is_playing (widget->priv->player) &&
+            gvc_mpris_player_get_can_seek (widget->priv->player)) {
+                widget->priv->seek_timer_id = g_timeout_add_seconds (1, seek_timer_cb, widget);
+                seek_timer_cb (widget);
+        }
+}
+
+static void
+update_metadata (GvcPlayerWidget *widget)
+{
+        const gchar *title;
+        const gchar *artist;
+        gint64       length;
+        gchar       *total;
+        gchar       *label;
+
+        if (widget->priv->player == NULL)
+                return;
+
+        title = gvc_mpris_player_get_title (widget->priv->player);
+        artist = gvc_mpris_player_get_artist (widget->priv->player);
+
+        gtk_label_set_text (widget->priv->title_label,
+                            title[0] != '\0' ? title : _("Unknown Title"));
+        gtk_label_set_text (widget->priv->artist_label,
+                            artist[0] != '\0' ? artist : _("Unknown Artist"));
+
+        length = gvc_mpris_player_get_length (widget->priv->player) / G_USEC_PER_SEC;
+        gtk_range_set_range (GTK_RANGE (widget->priv->seek_scale), 0, MAX (length, 1));
+        total = format_time (length);
+        label = g_strdup_printf ("0:00 / %s", total);
+        gtk_label_set_text (widget->priv->time_label, label);
+        g_free (total);
+        g_free (label);
+
+        update_cover (widget);
+        ensure_seek_timer (widget);
+}
+
+static void
+update_status (GvcPlayerWidget *widget)
+{
+        const gchar *status;
+        gchar       *label;
+
+        if (widget->priv->player == NULL)
+                return;
+
+        status = gvc_mpris_player_get_playback_status (widget->priv->player);
+        label = g_strdup_printf ("%s - %s",
+                                 gvc_mpris_player_get_identity (widget->priv->player),
+                                 status);
+        gtk_label_set_text (widget->priv->player_label, label);
+        g_free (label);
+
+        gtk_button_set_image (widget->priv->play_button,
+                              gtk_image_new_from_icon_name (gvc_mpris_player_is_playing (widget->priv->player) ?
+                                                            "media-playback-pause-symbolic" :
+                                                            "media-playback-start-symbolic",
+                                                            GTK_ICON_SIZE_BUTTON));
+        ensure_seek_timer (widget);
+}
+
+static void
+update_capabilities (GvcPlayerWidget *widget)
+{
+        const gchar *loop_status;
+        const gchar *loop_icon = "media-playlist-repeat-symbolic";
+
+        if (widget->priv->player == NULL)
+                return;
+
+        gtk_widget_set_sensitive (GTK_WIDGET (widget->priv->prev_button),
+                                  gvc_mpris_player_get_can_go_previous (widget->priv->player));
+        gtk_widget_set_sensitive (GTK_WIDGET (widget->priv->next_button),
+                                  gvc_mpris_player_get_can_go_next (widget->priv->player));
+        gtk_widget_set_sensitive (GTK_WIDGET (widget->priv->seek_scale),
+                                  gvc_mpris_player_get_can_seek (widget->priv->player));
+        gtk_widget_set_visible (GTK_WIDGET (widget->priv->raise_button),
+                                gvc_mpris_player_get_can_raise (widget->priv->player));
+        gtk_widget_set_visible (GTK_WIDGET (widget->priv->quit_button),
+                                gvc_mpris_player_get_can_quit (widget->priv->player));
+        gtk_toggle_button_set_active (widget->priv->shuffle_button,
+                                      gvc_mpris_player_get_shuffle (widget->priv->player));
+
+        loop_status = gvc_mpris_player_get_loop_status (widget->priv->player);
+        if (g_strcmp0 (loop_status, "Track") == 0)
+                loop_icon = "media-playlist-repeat-song-symbolic";
+        else if (g_strcmp0 (loop_status, "None") == 0)
+                loop_icon = "media-playlist-consecutive-symbolic";
+
+        gtk_button_set_image (widget->priv->loop_button,
+                              gtk_image_new_from_icon_name (loop_icon, GTK_ICON_SIZE_BUTTON));
+        ensure_seek_timer (widget);
+}
+
+static void
+on_player_metadata_changed (GvcMprisPlayer  *player,
+                            GvcPlayerWidget *widget)
+{
+        update_metadata (widget);
+}
+
+static void
+on_player_status_changed (GvcMprisPlayer  *player,
+                          GvcPlayerWidget *widget)
+{
+        update_status (widget);
+}
+
+static void
+on_player_capabilities_changed (GvcMprisPlayer  *player,
+                                GvcPlayerWidget *widget)
+{
+        update_capabilities (widget);
+}
+
+static void
+on_player_combo_changed (GtkComboBox     *combo,
+                         GvcPlayerWidget *widget)
+{
+        GtkTreeIter     iter;
+        GvcMprisPlayer *player = NULL;
+
+        if (widget->priv->updating_players)
+                return;
+
+        if (!gtk_combo_box_get_active_iter (combo, &iter))
+                return;
+
+        gtk_tree_model_get (gtk_combo_box_get_model (combo),
+                            &iter,
+                            PLAYER_COLUMN_PLAYER, &player,
+                            -1);
+
+        if (player != NULL) {
+                g_signal_emit (widget, signals[PLAYER_SELECTED], 0, player);
+                g_object_unref (player);
+        }
+}
+
+static GtkWidget *
+new_icon_button (const gchar *icon_name,
+                 const gchar *tooltip)
+{
+        GtkWidget *button;
+
+        button = gtk_button_new_from_icon_name (icon_name, GTK_ICON_SIZE_BUTTON);
+        gtk_button_set_relief (GTK_BUTTON (button), GTK_RELIEF_NONE);
+        gtk_widget_set_tooltip_text (button, tooltip);
+
+        return button;
+}
+
+static GtkWidget *
+new_icon_toggle_button (const gchar *icon_name,
+                        const gchar *tooltip)
+{
+        GtkWidget *button;
+        GtkWidget *image;
+
+        button = gtk_toggle_button_new ();
+        image = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_BUTTON);
+        gtk_button_set_image (GTK_BUTTON (button), image);
+        gtk_button_set_relief (GTK_BUTTON (button), GTK_RELIEF_NONE);
+        gtk_widget_set_tooltip_text (button, tooltip);
+
+        return button;
+}
+
+static void
+make_overlay_label (GtkLabel *label)
+{
+        GdkRGBA white = { 1.0, 1.0, 1.0, 1.0 };
+
+        gtk_widget_override_color (GTK_WIDGET (label),
+                                   GTK_STATE_FLAG_NORMAL,
+                                   &white);
+}
+
+static void on_prev_clicked (GtkButton *button, GvcPlayerWidget *widget) { gvc_mpris_player_previous (widget->priv->player); }
+static void on_play_clicked (GtkButton *button, GvcPlayerWidget *widget) { gvc_mpris_player_play_pause (widget->priv->player); }
+static void on_stop_clicked (GtkButton *button, GvcPlayerWidget *widget) { gvc_mpris_player_stop (widget->priv->player); }
+static void on_next_clicked (GtkButton *button, GvcPlayerWidget *widget) { gvc_mpris_player_next (widget->priv->player); }
+static void on_raise_clicked (GtkButton *button, GvcPlayerWidget *widget) { gvc_mpris_player_raise (widget->priv->player); }
+static void on_quit_clicked (GtkButton *button, GvcPlayerWidget *widget) { gvc_mpris_player_quit (widget->priv->player); }
+
+static void
+on_shuffle_toggled (GtkToggleButton *button,
+                    GvcPlayerWidget *widget)
+{
+        if (widget->priv->player == NULL)
+                return;
+
+        gvc_mpris_player_set_shuffle (widget->priv->player,
+                                      gtk_toggle_button_get_active (button));
+}
+
+static void
+on_loop_clicked (GtkButton       *button,
+                 GvcPlayerWidget *widget)
+{
+        const gchar *status;
+        const gchar *next = "Playlist";
+
+        if (widget->priv->player == NULL)
+                return;
+
+        status = gvc_mpris_player_get_loop_status (widget->priv->player);
+        if (g_strcmp0 (status, "Playlist") == 0)
+                next = "Track";
+        else if (g_strcmp0 (status, "Track") == 0)
+                next = "None";
+
+        gvc_mpris_player_set_loop_status (widget->priv->player, next);
+}
+
+static gboolean
+on_seek_button_release (GtkWidget      *scale,
+                        GdkEventButton *event,
+                        GvcPlayerWidget *widget)
+{
+        gint64 value;
+
+        if (widget->priv->player == NULL ||
+            widget->priv->updating_seek ||
+            !gvc_mpris_player_get_can_seek (widget->priv->player))
+                return FALSE;
+
+        value = gtk_range_get_value (GTK_RANGE (scale)) * G_USEC_PER_SEC;
+        gvc_mpris_player_set_position (widget->priv->player,
+                                       gvc_mpris_player_get_track_id (widget->priv->player),
+                                       value);
+        return FALSE;
+}
+
+static gboolean
+seek_by_scroll_event (GvcPlayerWidget *widget,
+                      GdkEventScroll  *event)
+{
+        gdouble current;
+        gdouble lower;
+        gdouble upper;
+        gdouble step;
+        gdouble delta;
+        gint64  value;
+
+        if (widget->priv->player == NULL ||
+            widget->priv->updating_seek ||
+            !gvc_mpris_player_get_can_seek (widget->priv->player))
+                return TRUE;
+
+        lower = gtk_adjustment_get_lower (gtk_range_get_adjustment (GTK_RANGE (widget->priv->seek_scale)));
+        upper = gtk_adjustment_get_upper (gtk_range_get_adjustment (GTK_RANGE (widget->priv->seek_scale)));
+        current = gtk_range_get_value (GTK_RANGE (widget->priv->seek_scale));
+        step = 5.0;
+        delta = 0.0;
+
+        switch (event->direction) {
+        case GDK_SCROLL_UP:
+        case GDK_SCROLL_RIGHT:
+                delta = step;
+                break;
+        case GDK_SCROLL_DOWN:
+        case GDK_SCROLL_LEFT:
+                delta = -step;
+                break;
+        case GDK_SCROLL_SMOOTH:
+                delta = -event->delta_y * step;
+                if (delta == 0.0)
+                        delta = event->delta_x * step;
+                break;
+        default:
+                break;
+        }
+
+        if (delta == 0.0)
+                return TRUE;
+
+        current = CLAMP (current + delta, lower, upper);
+        gtk_range_set_value (GTK_RANGE (widget->priv->seek_scale), current);
+        value = current * G_USEC_PER_SEC;
+        gvc_mpris_player_set_position (widget->priv->player,
+                                       gvc_mpris_player_get_track_id (widget->priv->player),
+                                       value);
+        return TRUE;
+}
+
+static gboolean
+on_seek_scroll_event (GtkWidget       *scale,
+                      GdkEventScroll  *event,
+                      GvcPlayerWidget *widget)
+{
+        return seek_by_scroll_event (widget, event);
+}
+
+static void
+gvc_player_widget_dispose (GObject *object)
+{
+        GvcPlayerWidget *widget = GVC_PLAYER_WIDGET (object);
+
+        if (widget->priv->seek_timer_id != 0) {
+                g_source_remove (widget->priv->seek_timer_id);
+                widget->priv->seek_timer_id = 0;
+        }
+
+        gvc_player_widget_set_player (widget, NULL);
+
+        G_OBJECT_CLASS (gvc_player_widget_parent_class)->dispose (object);
+}
+
+static void
+gvc_player_widget_class_init (GvcPlayerWidgetClass *klass)
+{
+        GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+        object_class->dispose = gvc_player_widget_dispose;
+
+        signals[PLAYER_SELECTED] =
+                g_signal_new ("player-selected",
+                              G_TYPE_FROM_CLASS (klass),
+                              G_SIGNAL_RUN_LAST,
+                              0,
+                              NULL,
+                              NULL,
+                              NULL,
+                              G_TYPE_NONE,
+                              1,
+                              GVC_TYPE_MPRIS_PLAYER);
+}
+
+static void
+gvc_player_widget_init (GvcPlayerWidget *widget)
+{
+        GtkWidget *header;
+        GtkListStore *combo_store;
+        GtkCellRenderer *renderer;
+        GtkWidget *overlay;
+        GtkWidget *cover_frame;
+        GtkWidget *overlay_event_box;
+        GtkWidget *info_box;
+        GtkWidget *controls;
+        GtkWidget *seek_box;
+        GdkRGBA    overlay_color = { 0.0, 0.0, 0.0, 0.62 };
+
+        widget->priv = gvc_player_widget_get_instance_private (widget);
+
+        gtk_widget_set_no_show_all (GTK_WIDGET (widget), TRUE);
+        gtk_orientable_set_orientation (GTK_ORIENTABLE (widget), GTK_ORIENTATION_VERTICAL);
+        gtk_box_set_spacing (GTK_BOX (widget), 6);
+        gtk_container_set_border_width (GTK_CONTAINER (widget), 8);
+        gtk_widget_set_size_request (GTK_WIDGET (widget), PLAYER_WIDTH, -1);
+
+        header = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 4);
+        widget->priv->player_label = GTK_LABEL (gtk_label_new (""));
+        combo_store = gtk_list_store_new (N_PLAYER_COLUMNS,
+                                          G_TYPE_STRING,
+                                          GVC_TYPE_MPRIS_PLAYER);
+        widget->priv->player_combo = GTK_COMBO_BOX (gtk_combo_box_new_with_model (GTK_TREE_MODEL (combo_store)));
+        renderer = gtk_cell_renderer_text_new ();
+        gtk_cell_layout_pack_start (GTK_CELL_LAYOUT (widget->priv->player_combo), renderer, TRUE);
+        gtk_cell_layout_add_attribute (GTK_CELL_LAYOUT (widget->priv->player_combo),
+                                       renderer,
+                                       "text",
+                                       PLAYER_COLUMN_LABEL);
+        gtk_widget_set_no_show_all (GTK_WIDGET (widget->priv->player_combo), TRUE);
+        gtk_widget_set_tooltip_text (GTK_WIDGET (widget->priv->player_combo), _("Choose Player"));
+        g_object_unref (combo_store);
+        widget->priv->raise_button = GTK_BUTTON (new_icon_button ("go-up-symbolic", _("Open Player")));
+        widget->priv->quit_button = GTK_BUTTON (new_icon_button ("window-close-symbolic", _("Quit Player")));
+        gtk_label_set_ellipsize (widget->priv->player_label, PANGO_ELLIPSIZE_END);
+        gtk_label_set_max_width_chars (widget->priv->player_label, 34);
+        gtk_label_set_xalign (widget->priv->player_label, 0.0);
+        gtk_box_pack_start (GTK_BOX (header), GTK_WIDGET (widget->priv->player_label), TRUE, TRUE, 0);
+        gtk_box_pack_start (GTK_BOX (header), GTK_WIDGET (widget->priv->player_combo), TRUE, TRUE, 0);
+        gtk_box_pack_start (GTK_BOX (header), GTK_WIDGET (widget->priv->raise_button), FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (header), GTK_WIDGET (widget->priv->quit_button), FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (widget), header, FALSE, FALSE, 0);
+
+        overlay = gtk_overlay_new ();
+        gtk_widget_set_halign (overlay, GTK_ALIGN_CENTER);
+        gtk_widget_set_size_request (overlay, COVER_SIZE, COVER_SIZE);
+
+        cover_frame = gtk_aspect_frame_new (NULL, 0.5, 0.5, 1.0, FALSE);
+        gtk_frame_set_shadow_type (GTK_FRAME (cover_frame), GTK_SHADOW_NONE);
+        gtk_widget_set_size_request (cover_frame, COVER_SIZE, COVER_SIZE);
+        widget->priv->cover = GTK_IMAGE (gtk_image_new ());
+        gtk_widget_set_size_request (GTK_WIDGET (widget->priv->cover), COVER_SIZE, COVER_SIZE);
+        set_cover_fallback (widget);
+        gtk_container_add (GTK_CONTAINER (cover_frame), GTK_WIDGET (widget->priv->cover));
+        gtk_container_add (GTK_CONTAINER (overlay), cover_frame);
+
+        overlay_event_box = gtk_event_box_new ();
+        gtk_widget_set_halign (overlay_event_box, GTK_ALIGN_FILL);
+        gtk_widget_set_valign (overlay_event_box, GTK_ALIGN_END);
+        gtk_widget_override_background_color (overlay_event_box,
+                                             GTK_STATE_FLAG_NORMAL,
+                                             &overlay_color);
+
+        info_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 4);
+        gtk_container_set_border_width (GTK_CONTAINER (info_box), 8);
+        gtk_container_add (GTK_CONTAINER (overlay_event_box), info_box);
+
+        widget->priv->title_label = GTK_LABEL (gtk_label_new (_("Unknown Title")));
+        widget->priv->artist_label = GTK_LABEL (gtk_label_new (_("Unknown Artist")));
+        gtk_label_set_ellipsize (widget->priv->title_label, PANGO_ELLIPSIZE_NONE);
+        gtk_label_set_ellipsize (widget->priv->artist_label, PANGO_ELLIPSIZE_NONE);
+        gtk_label_set_line_wrap (widget->priv->title_label, TRUE);
+        gtk_label_set_line_wrap (widget->priv->artist_label, TRUE);
+        gtk_label_set_line_wrap_mode (widget->priv->title_label, PANGO_WRAP_WORD_CHAR);
+        gtk_label_set_line_wrap_mode (widget->priv->artist_label, PANGO_WRAP_WORD_CHAR);
+        gtk_label_set_max_width_chars (widget->priv->title_label, 30);
+        gtk_label_set_max_width_chars (widget->priv->artist_label, 30);
+        gtk_label_set_xalign (widget->priv->title_label, 0.0);
+        gtk_label_set_xalign (widget->priv->artist_label, 0.0);
+        make_overlay_label (widget->priv->title_label);
+        make_overlay_label (widget->priv->artist_label);
+        gtk_box_pack_start (GTK_BOX (info_box), GTK_WIDGET (widget->priv->artist_label), FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (info_box), GTK_WIDGET (widget->priv->title_label), FALSE, FALSE, 0);
+
+        controls = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 2);
+        gtk_widget_set_halign (controls, GTK_ALIGN_CENTER);
+        widget->priv->prev_button = GTK_BUTTON (new_icon_button ("media-skip-backward-symbolic", _("Previous")));
+        widget->priv->play_button = GTK_BUTTON (new_icon_button ("media-playback-start-symbolic", _("Play/Pause")));
+        widget->priv->stop_button = GTK_BUTTON (new_icon_button ("media-playback-stop-symbolic", _("Stop")));
+        widget->priv->next_button = GTK_BUTTON (new_icon_button ("media-skip-forward-symbolic", _("Next")));
+        widget->priv->loop_button = GTK_BUTTON (new_icon_button ("media-playlist-repeat-symbolic", _("Repeat")));
+        widget->priv->shuffle_button = GTK_TOGGLE_BUTTON (new_icon_toggle_button ("media-playlist-shuffle-symbolic", _("Shuffle")));
+        gtk_box_pack_start (GTK_BOX (controls), GTK_WIDGET (widget->priv->prev_button), FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (controls), GTK_WIDGET (widget->priv->play_button), FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (controls), GTK_WIDGET (widget->priv->stop_button), FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (controls), GTK_WIDGET (widget->priv->next_button), FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (controls), GTK_WIDGET (widget->priv->loop_button), FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (controls), GTK_WIDGET (widget->priv->shuffle_button), FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (info_box), controls, FALSE, FALSE, 0);
+
+        gtk_overlay_add_overlay (GTK_OVERLAY (overlay), overlay_event_box);
+        gtk_overlay_set_overlay_pass_through (GTK_OVERLAY (overlay), overlay_event_box, FALSE);
+        gtk_box_pack_start (GTK_BOX (widget), overlay, FALSE, FALSE, 0);
+
+        seek_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+        widget->priv->seek_scale = GTK_SCALE (gtk_scale_new_with_range (GTK_ORIENTATION_HORIZONTAL, 0, 1, 1));
+        gtk_scale_set_draw_value (widget->priv->seek_scale, FALSE);
+        gtk_widget_set_hexpand (GTK_WIDGET (widget->priv->seek_scale), TRUE);
+        gtk_widget_set_size_request (GTK_WIDGET (widget->priv->seek_scale), 210, -1);
+        widget->priv->time_label = GTK_LABEL (gtk_label_new ("0:00 / 0:00"));
+        gtk_label_set_width_chars (widget->priv->time_label, 11);
+        gtk_label_set_xalign (widget->priv->time_label, 1.0);
+        gtk_box_pack_start (GTK_BOX (seek_box), GTK_WIDGET (widget->priv->seek_scale), TRUE, TRUE, 0);
+        gtk_box_pack_start (GTK_BOX (seek_box), GTK_WIDGET (widget->priv->time_label), FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (widget), seek_box, FALSE, FALSE, 0);
+
+        g_signal_connect (widget->priv->prev_button, "clicked", G_CALLBACK (on_prev_clicked), widget);
+        g_signal_connect (widget->priv->play_button, "clicked", G_CALLBACK (on_play_clicked), widget);
+        g_signal_connect (widget->priv->stop_button, "clicked", G_CALLBACK (on_stop_clicked), widget);
+        g_signal_connect (widget->priv->next_button, "clicked", G_CALLBACK (on_next_clicked), widget);
+        g_signal_connect (widget->priv->raise_button, "clicked", G_CALLBACK (on_raise_clicked), widget);
+        g_signal_connect (widget->priv->quit_button, "clicked", G_CALLBACK (on_quit_clicked), widget);
+        g_signal_connect (widget->priv->loop_button, "clicked", G_CALLBACK (on_loop_clicked), widget);
+        g_signal_connect (widget->priv->shuffle_button, "toggled", G_CALLBACK (on_shuffle_toggled), widget);
+        g_signal_connect (widget->priv->seek_scale, "button-release-event", G_CALLBACK (on_seek_button_release), widget);
+        g_signal_connect (widget->priv->seek_scale, "scroll-event", G_CALLBACK (on_seek_scroll_event), widget);
+        g_signal_connect (widget->priv->player_combo, "changed", G_CALLBACK (on_player_combo_changed), widget);
+}
+
+GtkWidget *
+gvc_player_widget_new (void)
+{
+        return g_object_new (GVC_TYPE_PLAYER_WIDGET, NULL);
+}
+
+void
+gvc_player_widget_set_player (GvcPlayerWidget *widget,
+                              GvcMprisPlayer  *player)
+{
+        g_return_if_fail (GVC_IS_PLAYER_WIDGET (widget));
+
+        if (widget->priv->player == player)
+                return;
+
+        if (widget->priv->player != NULL) {
+                g_signal_handlers_disconnect_by_data (widget->priv->player, widget);
+                g_clear_object (&widget->priv->player);
+        }
+
+        if (player != NULL)
+                widget->priv->player = g_object_ref (player);
+
+        if (widget->priv->player != NULL) {
+                g_signal_connect (widget->priv->player, "metadata-changed", G_CALLBACK (on_player_metadata_changed), widget);
+                g_signal_connect (widget->priv->player, "status-changed", G_CALLBACK (on_player_status_changed), widget);
+                g_signal_connect (widget->priv->player, "capabilities-changed", G_CALLBACK (on_player_capabilities_changed), widget);
+                update_metadata (widget);
+                update_status (widget);
+                update_capabilities (widget);
+                gtk_widget_set_no_show_all (GTK_WIDGET (widget), FALSE);
+                gtk_widget_show_all (GTK_WIDGET (widget));
+                gtk_widget_set_no_show_all (GTK_WIDGET (widget), TRUE);
+                gtk_widget_show (GTK_WIDGET (widget));
+        } else {
+                gtk_widget_hide (GTK_WIDGET (widget));
+        }
+}
+
+void
+gvc_player_widget_set_players (GvcPlayerWidget *widget,
+                               GList           *players,
+                               GvcMprisPlayer  *active_player)
+{
+        GtkListStore *store;
+        GtkTreeIter   iter;
+        GList        *l;
+        gint          count = 0;
+        gint          active_index = -1;
+
+        g_return_if_fail (GVC_IS_PLAYER_WIDGET (widget));
+
+        store = GTK_LIST_STORE (gtk_combo_box_get_model (widget->priv->player_combo));
+
+        widget->priv->updating_players = TRUE;
+        gtk_list_store_clear (store);
+
+        for (l = players; l != NULL; l = l->next) {
+                GvcMprisPlayer *player = GVC_MPRIS_PLAYER (l->data);
+                const gchar    *label;
+
+                if (!gvc_mpris_player_is_ready (player))
+                        continue;
+
+                label = gvc_mpris_player_get_identity (player);
+                if (label == NULL || label[0] == '\0')
+                        label = gvc_mpris_player_get_bus_name (player);
+
+                gtk_list_store_append (store, &iter);
+                gtk_list_store_set (store,
+                                    &iter,
+                                    PLAYER_COLUMN_LABEL, label,
+                                    PLAYER_COLUMN_PLAYER, player,
+                                    -1);
+
+                if (player == active_player)
+                        active_index = count;
+
+                count++;
+        }
+
+        gtk_combo_box_set_active (widget->priv->player_combo, active_index);
+        widget->priv->updating_players = FALSE;
+
+        if (count > 1) {
+                gtk_widget_hide (GTK_WIDGET (widget->priv->player_label));
+                gtk_widget_show (GTK_WIDGET (widget->priv->player_combo));
+        } else {
+                gtk_widget_hide (GTK_WIDGET (widget->priv->player_combo));
+                gtk_widget_show (GTK_WIDGET (widget->priv->player_label));
+        }
+}
+
+gboolean
+gvc_player_widget_scroll_is_seek (GvcPlayerWidget *widget,
+                                  GdkEventScroll  *event)
+{
+        GtkAllocation allocation;
+        GdkWindow    *window;
+        gint          x;
+        gint          y;
+
+        g_return_val_if_fail (GVC_IS_PLAYER_WIDGET (widget), FALSE);
+
+        if (!gtk_widget_get_visible (GTK_WIDGET (widget->priv->seek_scale)) ||
+            gtk_widget_get_window (GTK_WIDGET (widget->priv->seek_scale)) == NULL)
+                return FALSE;
+
+        window = gtk_widget_get_window (GTK_WIDGET (widget->priv->seek_scale));
+        gdk_window_get_origin (window, &x, &y);
+        gtk_widget_get_allocation (GTK_WIDGET (widget->priv->seek_scale), &allocation);
+
+        return event->x_root >= x + allocation.x &&
+               event->x_root < x + allocation.x + allocation.width &&
+               event->y_root >= y + allocation.y &&
+               event->y_root < y + allocation.y + allocation.height;
+}
+
+gboolean
+gvc_player_widget_handle_seek_scroll (GvcPlayerWidget *widget,
+                                      GdkEventScroll  *event)
+{
+        g_return_val_if_fail (GVC_IS_PLAYER_WIDGET (widget), TRUE);
+
+        return seek_by_scroll_event (widget, event);
+}

--- a/mate-volume-control/gvc-player-widget.h
+++ b/mate-volume-control/gvc-player-widget.h
@@ -1,0 +1,45 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*- */
+
+#ifndef __GVC_PLAYER_WIDGET_H
+#define __GVC_PLAYER_WIDGET_H
+
+#include <gtk/gtk.h>
+
+#include "gvc-mpris-player.h"
+
+G_BEGIN_DECLS
+
+#define GVC_TYPE_PLAYER_WIDGET         (gvc_player_widget_get_type ())
+#define GVC_PLAYER_WIDGET(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), GVC_TYPE_PLAYER_WIDGET, GvcPlayerWidget))
+#define GVC_IS_PLAYER_WIDGET(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), GVC_TYPE_PLAYER_WIDGET))
+
+typedef struct _GvcPlayerWidget        GvcPlayerWidget;
+typedef struct _GvcPlayerWidgetClass   GvcPlayerWidgetClass;
+typedef struct _GvcPlayerWidgetPrivate GvcPlayerWidgetPrivate;
+
+struct _GvcPlayerWidget
+{
+        GtkBox                  parent;
+        GvcPlayerWidgetPrivate *priv;
+};
+
+struct _GvcPlayerWidgetClass
+{
+        GtkBoxClass             parent_class;
+};
+
+GType       gvc_player_widget_get_type   (void) G_GNUC_CONST;
+GtkWidget * gvc_player_widget_new        (void);
+void        gvc_player_widget_set_player (GvcPlayerWidget *widget,
+                                           GvcMprisPlayer  *player);
+void        gvc_player_widget_set_players (GvcPlayerWidget *widget,
+                                            GList           *players,
+                                            GvcMprisPlayer  *active_player);
+gboolean    gvc_player_widget_scroll_is_seek (GvcPlayerWidget *widget,
+                                               GdkEventScroll  *event);
+gboolean    gvc_player_widget_handle_seek_scroll (GvcPlayerWidget *widget,
+                                                   GdkEventScroll  *event);
+
+G_END_DECLS
+
+#endif /* __GVC_PLAYER_WIDGET_H */

--- a/mate-volume-control/gvc-status-icon.c
+++ b/mate-volume-control/gvc-status-icon.c
@@ -26,12 +26,16 @@
 #include <glib.h>
 #include <glib/gi18n.h>
 #include <glib-object.h>
+#include <gio/gdesktopappinfo.h>
 #include <gtk/gtk.h>
 
 #include <libmatemixer/matemixer.h>
 
 #include "gvc-status-icon.h"
 #include "gvc-stream-status-icon.h"
+#include "gvc-mpris-manager.h"
+#include "gvc-mpris-player.h"
+#include "gvc-player-widget.h"
 
 static const gchar *icon_names_output[] = {
         "audio-volume-muted",
@@ -55,10 +59,72 @@ struct _GvcStatusIconPrivate
         GvcStreamStatusIcon *icon_output;
         gboolean             running;
         MateMixerContext    *context;
+        MateMixerStream     *output;
         MateMixerStream     *input;
+        GvcMprisManager     *mpris_manager;
+        GvcMprisPlayer      *active_player;
+        GvcMprisPlayer      *selected_player;
+        GtkWidget           *player_widget;
+        GSettings           *applet_settings;
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE (GvcStatusIcon, gvc_status_icon, G_TYPE_OBJECT)
+
+static void update_active_player (GvcStatusIcon *status_icon);
+
+static GSettings *
+new_applet_settings (void)
+{
+        GSettingsSchemaSource *source;
+        GSettingsSchema       *schema;
+
+        source = g_settings_schema_source_get_default ();
+        if (source == NULL)
+                return NULL;
+
+        schema = g_settings_schema_source_lookup (source,
+                                                  "org.mate.volume-control",
+                                                  TRUE);
+        if (schema == NULL)
+                return NULL;
+
+        g_settings_schema_unref (schema);
+
+        return g_settings_new ("org.mate.volume-control");
+}
+
+static gboolean
+settings_get_boolean (GvcStatusIcon *status_icon,
+                      const gchar   *key,
+                      gboolean       fallback)
+{
+        if (status_icon->priv->applet_settings == NULL)
+                return fallback;
+
+        return g_settings_get_boolean (status_icon->priv->applet_settings, key);
+}
+
+static gboolean
+is_recording_application_control (MateMixerStreamControl *control)
+{
+        MateMixerAppInfo *app_info;
+        const gchar      *app_id;
+
+        if (mate_mixer_stream_control_get_role (control) != MATE_MIXER_STREAM_CONTROL_ROLE_APPLICATION)
+                return FALSE;
+
+        app_info = mate_mixer_stream_control_get_app_info (control);
+        if (app_info == NULL)
+                return TRUE;
+
+        app_id = mate_mixer_app_info_get_id (app_info);
+        if (app_id == NULL)
+                return TRUE;
+
+        return strcmp (app_id, "org.mate.VolumeControl") != 0 &&
+               strcmp (app_id, "org.gnome.VolumeControl") != 0 &&
+               strcmp (app_id, "org.PulseAudio.pavucontrol") != 0;
+}
 
 static void
 update_icon_input (GvcStatusIcon *status_icon)
@@ -66,73 +132,72 @@ update_icon_input (GvcStatusIcon *status_icon)
         MateMixerStreamControl *control = NULL;
         gboolean                show = FALSE;
 
-        /* Enable the input icon in case there is an input stream present and there
-         * is a non-mixer application using the input */
+        /* Enable the input icon when any application is recording, regardless of
+         * which input stream it uses */
         if (status_icon->priv->input != NULL) {
-                const gchar *app_id;
-                const GList *inputs =
-                        mate_mixer_stream_list_controls (status_icon->priv->input);
+                const gchar *stream_name;
+                const GList *inputs = mate_mixer_stream_list_controls (status_icon->priv->input);
 
                 control = mate_mixer_stream_get_default_control (status_icon->priv->input);
 
-                const gchar *stream_name =
-                        mate_mixer_stream_get_name (status_icon->priv->input);
-                g_debug ("Got stream name %s", stream_name);
-                if (g_str_has_suffix (stream_name, ".monitor")) {
+                stream_name = mate_mixer_stream_get_name (status_icon->priv->input);
+                if (stream_name != NULL && g_str_has_suffix (stream_name, ".monitor"))
                         inputs = NULL;
-                        g_debug ("Stream is a monitor, ignoring");
-                }
 
                 while (inputs != NULL) {
-                        MateMixerStreamControl    *input =
-                                MATE_MIXER_STREAM_CONTROL (inputs->data);
-                        MateMixerStreamControlRole role =
-                                mate_mixer_stream_control_get_role (input);
+                        MateMixerStreamControl *input = MATE_MIXER_STREAM_CONTROL (inputs->data);
 
-                        if (role == MATE_MIXER_STREAM_CONTROL_ROLE_APPLICATION) {
-                                MateMixerAppInfo *app_info =
-                                        mate_mixer_stream_control_get_app_info (input);
-
-                                app_id = mate_mixer_app_info_get_id (app_info);
-                                if (app_id == NULL) {
-                                        /* A recording application which has no
-                                         * identifier set */
-                                        g_debug ("Found a recording application control %s",
-                                                 mate_mixer_stream_control_get_label (input));
-
-                                        if (G_UNLIKELY (control == NULL)) {
-                                                /* In the unlikely case when there is no
-                                                 * default input control, use the application
-                                                 * control for the icon */
-                                                control = input;
-                                        }
-                                        show = TRUE;
-                                        break;
-                                }
-
-                                if (strcmp (app_id, "org.mate.VolumeControl") != 0 &&
-                                    strcmp (app_id, "org.gnome.VolumeControl") != 0 &&
-                                    strcmp (app_id, "org.PulseAudio.pavucontrol") != 0) {
-                                        g_debug ("Found a recording application %s", app_id);
-
-                                        if (G_UNLIKELY (control == NULL))
-                                                control = input;
-
-                                        show = TRUE;
-                                        break;
-                                }
+                        if (is_recording_application_control (input)) {
+                                if (G_UNLIKELY (control == NULL))
+                                        control = input;
+                                show = TRUE;
+                                break;
                         }
                         inputs = inputs->next;
                 }
+        }
 
-                if (show == TRUE)
-                        g_debug ("Input icon enabled");
-                else
-                        g_debug ("There is no recording application, input icon disabled");
+        if (!show && status_icon->priv->context != NULL) {
+                const GList *streams;
+
+                streams = mate_mixer_context_list_streams (status_icon->priv->context);
+                while (streams != NULL && !show) {
+                        MateMixerStream *stream = MATE_MIXER_STREAM (streams->data);
+                        const gchar     *name;
+                        const GList     *inputs;
+
+                        if (stream == status_icon->priv->input ||
+                            mate_mixer_stream_get_direction (stream) != MATE_MIXER_DIRECTION_INPUT) {
+                                streams = streams->next;
+                                continue;
+                        }
+
+                        name = mate_mixer_stream_get_name (stream);
+                        if (name != NULL && g_str_has_suffix (name, ".monitor")) {
+                                streams = streams->next;
+                                continue;
+                        }
+
+                        inputs = mate_mixer_stream_list_controls (stream);
+                        while (inputs != NULL) {
+                                MateMixerStreamControl *input = MATE_MIXER_STREAM_CONTROL (inputs->data);
+
+                                if (is_recording_application_control (input)) {
+                                        control = mate_mixer_stream_get_default_control (stream);
+                                        if (control == NULL)
+                                                control = input;
+                                        show = TRUE;
+                                        break;
+                                }
+
+                                inputs = inputs->next;
+                        }
+
+                        streams = streams->next;
+                }
         }
 
         gvc_stream_status_icon_set_control (status_icon->priv->icon_input, control);
-
         gtk_status_icon_set_visible (GTK_STATUS_ICON (status_icon->priv->icon_input), show);
 }
 
@@ -148,49 +213,294 @@ update_icon_output (GvcStatusIcon *status_icon)
 
         gvc_stream_status_icon_set_control (status_icon->priv->icon_output, control);
 
-        if (control != NULL) {
-                g_debug ("Output icon enabled");
-                gtk_status_icon_set_visible (GTK_STATUS_ICON (status_icon->priv->icon_output),
-                                             TRUE);
-        }
-        else {
-                g_debug ("There is no output stream/control, output icon disabled");
-                gtk_status_icon_set_visible (GTK_STATUS_ICON (status_icon->priv->icon_output),
-                                             FALSE);
-        }
+        gtk_status_icon_set_visible (GTK_STATUS_ICON (status_icon->priv->icon_output),
+                                     control != NULL);
 }
 
 static void
-on_input_stream_control_added (MateMixerStream *stream,
-                               const gchar     *name,
-                               GvcStatusIcon       *status_icon)
+on_output_stream_control_added (MateMixerStream *stream,
+                                const gchar     *name,
+                                GvcStatusIcon   *status_icon)
 {
         MateMixerStreamControl *control;
 
         control = mate_mixer_stream_get_control (stream, name);
         if (G_LIKELY (control != NULL)) {
-                MateMixerStreamControlRole role =
-                        mate_mixer_stream_control_get_role (control);
+                MateMixerStreamControlRole role = mate_mixer_stream_control_get_role (control);
 
-                /* Non-application input control doesn't affect the icon */
                 if (role != MATE_MIXER_STREAM_CONTROL_ROLE_APPLICATION)
                         return;
         }
 
-        /* Either an application control has been added or we couldn't
-         * read the control, this shouldn't happen but let's revalidate the
-         * icon to be sure if it does */
+        update_icon_output (status_icon);
+}
+
+static void
+on_output_stream_control_removed (MateMixerStream *stream,
+                                  const gchar     *name,
+                                  GvcStatusIcon   *status_icon)
+{
+        update_icon_output (status_icon);
+}
+
+static void
+update_player_selector (GvcStatusIcon *status_icon)
+{
+        GList *players;
+
+        players = gvc_mpris_manager_get_players (status_icon->priv->mpris_manager);
+        gvc_player_widget_set_players (GVC_PLAYER_WIDGET (status_icon->priv->player_widget),
+                                       players,
+                                       status_icon->priv->active_player);
+        g_list_free (players);
+}
+
+static void
+on_player_widget_player_selected (GvcPlayerWidget *widget,
+                                  GvcMprisPlayer  *player,
+                                  GvcStatusIcon   *status_icon)
+{
+        g_clear_object (&status_icon->priv->selected_player);
+        if (player != NULL)
+                status_icon->priv->selected_player = g_object_ref (player);
+
+        update_active_player (status_icon);
+}
+
+static void
+on_status_icon_player_selected (GvcStreamStatusIcon *icon,
+                                GvcMprisPlayer      *player,
+                                GvcStatusIcon       *status_icon)
+{
+        g_clear_object (&status_icon->priv->selected_player);
+        if (player != NULL)
+                status_icon->priv->selected_player = g_object_ref (player);
+
+        update_active_player (status_icon);
+}
+
+static void
+on_mpris_player_changed (GvcMprisPlayer *player,
+                         GvcStatusIcon  *status_icon)
+{
+        update_active_player (status_icon);
+}
+
+static void
+update_active_player (GvcStatusIcon *status_icon)
+{
+        GvcMprisPlayer *player;
+        gboolean        show_player;
+
+        show_player = settings_get_boolean (status_icon, "show-player-controls", TRUE);
+
+        player = NULL;
+        if (status_icon->priv->selected_player != NULL &&
+            gvc_mpris_player_is_ready (status_icon->priv->selected_player))
+                player = status_icon->priv->selected_player;
+        if (player == NULL)
+                player = gvc_mpris_manager_get_best_player (status_icon->priv->mpris_manager);
+
+        if (player == status_icon->priv->active_player) {
+                if (player != NULL) {
+                        gvc_player_widget_set_player (GVC_PLAYER_WIDGET (status_icon->priv->player_widget),
+                                                      show_player ? player : NULL);
+                        gvc_stream_status_icon_set_player_widget_visible (status_icon->priv->icon_output,
+                                                                          show_player);
+                }
+                update_player_selector (status_icon);
+                return;
+        }
+
+        g_clear_object (&status_icon->priv->active_player);
+        if (player != NULL)
+                status_icon->priv->active_player = g_object_ref (player);
+
+        gvc_player_widget_set_player (GVC_PLAYER_WIDGET (status_icon->priv->player_widget),
+                                      show_player ? status_icon->priv->active_player : NULL);
+        gvc_stream_status_icon_set_mpris_player (status_icon->priv->icon_output,
+                                                 status_icon->priv->active_player);
+        gvc_stream_status_icon_set_player_widget_visible (status_icon->priv->icon_output,
+                                                          status_icon->priv->active_player != NULL &&
+                                                          show_player);
+        update_player_selector (status_icon);
+}
+
+static void
+remember_player (GvcStatusIcon  *status_icon,
+                 GvcMprisPlayer *player)
+{
+        const gchar *desktop_entry;
+        gchar      **known;
+        gboolean     found = FALSE;
+        gint         i;
+
+        if (status_icon->priv->applet_settings == NULL)
+                return;
+
+        desktop_entry = gvc_mpris_player_get_desktop_entry (player);
+        if (desktop_entry == NULL || desktop_entry[0] == '\0')
+                return;
+
+        known = g_settings_get_strv (status_icon->priv->applet_settings, "known-players");
+        for (i = 0; known != NULL && known[i] != NULL; i++) {
+                if (g_strcmp0 (known[i], desktop_entry) == 0) {
+                        found = TRUE;
+                        break;
+                }
+        }
+
+        if (!found) {
+                GPtrArray *array;
+
+                array = g_ptr_array_new_with_free_func (g_free);
+                for (i = 0; known != NULL && known[i] != NULL; i++)
+                        g_ptr_array_add (array, g_strdup (known[i]));
+                g_ptr_array_add (array, g_strdup (desktop_entry));
+                g_ptr_array_add (array, NULL);
+                g_settings_set_strv (status_icon->priv->applet_settings,
+                                     "known-players",
+                                     (const gchar * const *) array->pdata);
+                g_ptr_array_free (array, TRUE);
+        }
+
+        g_strfreev (known);
+}
+
+static void
+on_mpris_player_added (GvcMprisManager *manager,
+                       GvcMprisPlayer  *player,
+                       GvcStatusIcon   *status_icon)
+{
+        remember_player (status_icon, player);
+
+        g_signal_connect (player, "status-changed", G_CALLBACK (on_mpris_player_changed), status_icon);
+        g_signal_connect (player, "metadata-changed", G_CALLBACK (on_mpris_player_changed), status_icon);
+        g_signal_connect (player, "capabilities-changed", G_CALLBACK (on_mpris_player_changed), status_icon);
+
+        update_active_player (status_icon);
+}
+
+static void
+on_mpris_player_removed (GvcMprisManager *manager,
+                         const gchar     *bus_name,
+                         GvcStatusIcon   *status_icon)
+{
+        if (status_icon->priv->selected_player != NULL &&
+            g_strcmp0 (gvc_mpris_player_get_bus_name (status_icon->priv->selected_player), bus_name) == 0)
+                g_clear_object (&status_icon->priv->selected_player);
+
+        update_active_player (status_icon);
+}
+
+static void
+on_applet_settings_changed (GSettings     *settings,
+                            gchar         *key,
+                            GvcStatusIcon *status_icon)
+{
+        update_active_player (status_icon);
+}
+
+static void
+on_input_stream_control_added (MateMixerStream *stream,
+                               const gchar     *name,
+                               GvcStatusIcon   *status_icon)
+{
+        MateMixerStreamControl *control;
+
+        control = mate_mixer_stream_get_control (stream, name);
+        if (G_LIKELY (control != NULL)) {
+                MateMixerStreamControlRole role = mate_mixer_stream_control_get_role (control);
+                if (role != MATE_MIXER_STREAM_CONTROL_ROLE_APPLICATION)
+                        return;
+        }
+
         update_icon_input (status_icon);
 }
 
 static void
 on_input_stream_control_removed (MateMixerStream *stream,
                                  const gchar     *name,
-                                 GvcStatusIcon       *status_icon)
+                                 GvcStatusIcon   *status_icon)
 {
-        /* The removed stream could be an application input, which may cause
-         * the input status icon to disappear */
         update_icon_input (status_icon);
+}
+
+static void
+disconnect_input_stream_control_signals (GvcStatusIcon *status_icon)
+{
+        const GList *streams;
+
+        streams = mate_mixer_context_list_streams (status_icon->priv->context);
+        while (streams != NULL) {
+                MateMixerStream *stream = MATE_MIXER_STREAM (streams->data);
+
+                if (mate_mixer_stream_get_direction (stream) == MATE_MIXER_DIRECTION_INPUT) {
+                        g_signal_handlers_disconnect_by_func (G_OBJECT (stream),
+                                                              G_CALLBACK (on_input_stream_control_added),
+                                                              status_icon);
+                        g_signal_handlers_disconnect_by_func (G_OBJECT (stream),
+                                                              G_CALLBACK (on_input_stream_control_removed),
+                                                              status_icon);
+                }
+
+                streams = streams->next;
+        }
+}
+
+static void
+connect_input_stream_control_signals (GvcStatusIcon *status_icon)
+{
+        const GList *streams;
+
+        disconnect_input_stream_control_signals (status_icon);
+
+        streams = mate_mixer_context_list_streams (status_icon->priv->context);
+        while (streams != NULL) {
+                MateMixerStream *stream = MATE_MIXER_STREAM (streams->data);
+
+                if (mate_mixer_stream_get_direction (stream) == MATE_MIXER_DIRECTION_INPUT) {
+                        g_signal_connect (G_OBJECT (stream),
+                                          "control-added",
+                                          G_CALLBACK (on_input_stream_control_added),
+                                          status_icon);
+                        g_signal_connect (G_OBJECT (stream),
+                                          "control-removed",
+                                          G_CALLBACK (on_input_stream_control_removed),
+                                          status_icon);
+                }
+
+                streams = streams->next;
+        }
+}
+
+static gboolean
+update_default_output_stream (GvcStatusIcon *status_icon)
+{
+        MateMixerStream *stream;
+
+        stream = mate_mixer_context_get_default_output_stream (status_icon->priv->context);
+        if (stream == status_icon->priv->output)
+                return FALSE;
+
+        if (status_icon->priv->output != NULL) {
+                g_signal_handlers_disconnect_by_data (G_OBJECT (status_icon->priv->output), status_icon);
+                g_object_unref (status_icon->priv->output);
+        }
+
+        status_icon->priv->output = (stream == NULL) ? NULL : g_object_ref (stream);
+        if (status_icon->priv->output != NULL) {
+                g_signal_connect (G_OBJECT (status_icon->priv->output),
+                                  "control-added",
+                                  G_CALLBACK (on_output_stream_control_added),
+                                  status_icon);
+                g_signal_connect (G_OBJECT (status_icon->priv->output),
+                                  "control-removed",
+                                  G_CALLBACK (on_output_stream_control_removed),
+                                  status_icon);
+        }
+
+        return TRUE;
 }
 
 static gboolean
@@ -202,33 +512,19 @@ update_default_input_stream (GvcStatusIcon *status_icon)
         if (stream == status_icon->priv->input)
                 return FALSE;
 
-        /* The input stream has changed */
         if (status_icon->priv->input != NULL) {
-                g_signal_handlers_disconnect_by_data (G_OBJECT (status_icon->priv->input),
-                                                      status_icon);
+                g_signal_handlers_disconnect_by_data (G_OBJECT (status_icon->priv->input), status_icon);
                 g_object_unref (status_icon->priv->input);
         }
 
         status_icon->priv->input = (stream == NULL) ? NULL : g_object_ref (stream);
-        if (status_icon->priv->input != NULL) {
-                g_signal_connect (G_OBJECT (status_icon->priv->input),
-                                  "control-added",
-                                  G_CALLBACK (on_input_stream_control_added),
-                                  status_icon);
-                g_signal_connect (G_OBJECT (status_icon->priv->input),
-                                  "control-removed",
-                                  G_CALLBACK (on_input_stream_control_removed),
-                                  status_icon);
-        }
-
-        /* Return TRUE if the default input stream has changed */
         return TRUE;
 }
 
 static void
 on_context_state_notify (MateMixerContext *context,
                          GParamSpec       *pspec,
-                         GvcStatusIcon        *status_icon)
+                         GvcStatusIcon    *status_icon)
 {
         MateMixerState state = mate_mixer_context_get_state (context);
 
@@ -238,9 +534,10 @@ on_context_state_notify (MateMixerContext *context,
                 break;
 
         case MATE_MIXER_STATE_READY:
+                update_default_output_stream (status_icon);
                 update_default_input_stream (status_icon);
+                connect_input_stream_control_signals (status_icon);
 
-                /* Each status change may affect the visibility of the icons */
                 update_icon_output (status_icon);
                 update_icon_input (status_icon);
                 break;
@@ -252,20 +549,46 @@ on_context_state_notify (MateMixerContext *context,
 static void
 on_context_default_input_stream_notify (MateMixerContext *context,
                                         GParamSpec       *pspec,
-                                        GvcStatusIcon        *status_icon)
+                                        GvcStatusIcon    *status_icon)
 {
         if (update_default_input_stream (status_icon) == FALSE)
                 return;
 
+        connect_input_stream_control_signals (status_icon);
         update_icon_input (status_icon);
 }
 
 static void
 on_context_default_output_stream_notify (MateMixerContext *control,
                                          GParamSpec       *pspec,
-                                         GvcStatusIcon        *status_icon)
+                                         GvcStatusIcon    *status_icon)
 {
+        update_default_output_stream (status_icon);
         update_icon_output (status_icon);
+}
+
+static void
+on_context_stream_added (MateMixerContext *context,
+                         const gchar      *name,
+                         GvcStatusIcon    *status_icon)
+{
+        update_default_output_stream (status_icon);
+        update_default_input_stream (status_icon);
+        connect_input_stream_control_signals (status_icon);
+        update_icon_output (status_icon);
+        update_icon_input (status_icon);
+}
+
+static void
+on_context_stream_removed (MateMixerContext *context,
+                           const gchar      *name,
+                           GvcStatusIcon    *status_icon)
+{
+        update_default_output_stream (status_icon);
+        update_default_input_stream (status_icon);
+        connect_input_stream_control_signals (status_icon);
+        update_icon_output (status_icon);
+        update_icon_input (status_icon);
 }
 
 void
@@ -276,11 +599,8 @@ gvc_status_icon_start (GvcStatusIcon *status_icon)
         if (G_UNLIKELY (status_icon->priv->running == TRUE))
                 return;
 
-        if (G_UNLIKELY (mate_mixer_context_open (status_icon->priv->context) == FALSE)) {
-                /* Normally this should never happen, in the worst case we
-                 * should end up with the Null module */
+        if (G_UNLIKELY (mate_mixer_context_open (status_icon->priv->context) == FALSE))
                 g_warning ("Failed to connect to a sound system");
-        }
 
         g_debug ("StatusIcon has been started");
 
@@ -297,8 +617,19 @@ gvc_status_icon_dispose (GObject *object)
                                                       status_icon);
                 g_clear_object (&status_icon->priv->input);
         }
+        if (status_icon->priv->output != NULL) {
+                g_signal_handlers_disconnect_by_data (G_OBJECT (status_icon->priv->output),
+                                                      status_icon);
+                g_clear_object (&status_icon->priv->output);
+        }
+        if (status_icon->priv->context != NULL)
+                disconnect_input_stream_control_signals (status_icon);
 
         g_clear_object (&status_icon->priv->context);
+        g_clear_object (&status_icon->priv->active_player);
+        g_clear_object (&status_icon->priv->selected_player);
+        g_clear_object (&status_icon->priv->mpris_manager);
+        g_clear_object (&status_icon->priv->applet_settings);
         g_clear_object (&status_icon->priv->icon_input);
         g_clear_object (&status_icon->priv->icon_output);
 
@@ -321,6 +652,28 @@ gvc_status_icon_init (GvcStatusIcon *status_icon)
         status_icon->priv->icon_input  = gvc_stream_status_icon_new (NULL, icon_names_input);
         status_icon->priv->icon_output = gvc_stream_status_icon_new (NULL, icon_names_output);
 
+        status_icon->priv->applet_settings = new_applet_settings ();
+        gvc_stream_status_icon_set_applet_settings (status_icon->priv->icon_input,
+                                                    status_icon->priv->applet_settings);
+        gvc_stream_status_icon_set_applet_settings (status_icon->priv->icon_output,
+                                                    status_icon->priv->applet_settings);
+
+        status_icon->priv->player_widget = gvc_player_widget_new ();
+        gvc_stream_status_icon_set_player_widget (status_icon->priv->icon_output,
+                                                  status_icon->priv->player_widget);
+        g_signal_connect (status_icon->priv->player_widget,
+                          "player-selected",
+                          G_CALLBACK (on_player_widget_player_selected),
+                          status_icon);
+        g_signal_connect (status_icon->priv->icon_output,
+                          "player-selected",
+                          G_CALLBACK (on_status_icon_player_selected),
+                          status_icon);
+        g_signal_connect (status_icon->priv->icon_input,
+                          "player-selected",
+                          G_CALLBACK (on_status_icon_player_selected),
+                          status_icon);
+
         gvc_stream_status_icon_set_display_name (status_icon->priv->icon_input,  _("Input"));
         gvc_stream_status_icon_set_display_name (status_icon->priv->icon_output, _("Output"));
 
@@ -330,6 +683,16 @@ gvc_status_icon_init (GvcStatusIcon *status_icon)
                                    _("Sound Output Volume"));
 
         status_icon->priv->context = mate_mixer_context_new ();
+        status_icon->priv->mpris_manager = gvc_mpris_manager_new ();
+
+        gvc_stream_status_icon_set_mpris_manager (status_icon->priv->icon_output,
+                                                  status_icon->priv->mpris_manager);
+        gvc_stream_status_icon_set_mpris_manager (status_icon->priv->icon_input,
+                                                  status_icon->priv->mpris_manager);
+        gvc_stream_status_icon_set_mate_mixer_context (status_icon->priv->icon_output,
+                                                       status_icon->priv->context);
+        gvc_stream_status_icon_set_mate_mixer_context (status_icon->priv->icon_input,
+                                                       status_icon->priv->context);
 
         mate_mixer_context_set_app_name (status_icon->priv->context,
                                          _("MATE Volume Control StatusIcon"));
@@ -350,6 +713,28 @@ gvc_status_icon_init (GvcStatusIcon *status_icon)
                           "notify::default-output-stream",
                           G_CALLBACK (on_context_default_output_stream_notify),
                           status_icon);
+        g_signal_connect (G_OBJECT (status_icon->priv->context),
+                          "stream-added",
+                          G_CALLBACK (on_context_stream_added),
+                          status_icon);
+        g_signal_connect (G_OBJECT (status_icon->priv->context),
+                          "stream-removed",
+                          G_CALLBACK (on_context_stream_removed),
+                          status_icon);
+        g_signal_connect (G_OBJECT (status_icon->priv->mpris_manager),
+                          "player-added",
+                          G_CALLBACK (on_mpris_player_added),
+                          status_icon);
+        g_signal_connect (G_OBJECT (status_icon->priv->mpris_manager),
+                          "player-removed",
+                          G_CALLBACK (on_mpris_player_removed),
+                          status_icon);
+        if (status_icon->priv->applet_settings != NULL) {
+                g_signal_connect (G_OBJECT (status_icon->priv->applet_settings),
+                                  "changed",
+                                  G_CALLBACK (on_applet_settings_changed),
+                                  status_icon);
+        }
 }
 
 GvcStatusIcon *

--- a/mate-volume-control/gvc-stream-applet-icon.c
+++ b/mate-volume-control/gvc-stream-applet-icon.c
@@ -39,15 +39,25 @@
 #include <libmate-desktop/mate-desktop-utils.h>
 
 #include "gvc-channel-bar.h"
+#include "gvc-mpris-player.h"
+#include "gvc-player-widget.h"
 #include "gvc-stream-applet-icon.h"
 
 struct _GvcStreamAppletIconPrivate
 {
         GSettings              *sound_settings;
+        GSettings              *applet_settings;
         gchar                 **icon_names;
         GtkImage               *image;
         GtkWidget              *dock;
+        GtkWidget              *dock_box;
+        GtkWidget              *player_widget;
+        GtkWidget              *player_separator;
+        GtkWidget              *volume_box;
+        GtkImage               *volume_image;
         GtkWidget              *bar;
+        GvcMprisPlayer         *player;
+        gboolean                player_widget_visible;
         guint                   current_icon;
         gchar                  *display_name;
         MateMixerStreamControl *control;
@@ -67,8 +77,133 @@ enum
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
 static void gvc_stream_applet_icon_finalize   (GObject *object);
+static void update_icon                       (GvcStreamAppletIcon *icon);
 
 G_DEFINE_TYPE_WITH_PRIVATE (GvcStreamAppletIcon, gvc_stream_applet_icon, GTK_TYPE_EVENT_BOX)
+
+static void
+configure_volume_box_layout (GvcStreamAppletIcon *icon,
+                             GtkOrientation       orientation)
+{
+        if (icon->priv->volume_box == NULL ||
+            icon->priv->volume_image == NULL)
+                return;
+
+        gtk_orientable_set_orientation (GTK_ORIENTABLE (icon->priv->volume_box),
+                                        orientation);
+
+        if (orientation == GTK_ORIENTATION_HORIZONTAL) {
+                gtk_box_reorder_child (GTK_BOX (icon->priv->volume_box),
+                                       GTK_WIDGET (icon->priv->volume_image),
+                                       0);
+                gtk_box_reorder_child (GTK_BOX (icon->priv->volume_box),
+                                       icon->priv->bar,
+                                       1);
+        } else {
+                gtk_box_reorder_child (GTK_BOX (icon->priv->volume_box),
+                                       icon->priv->bar,
+                                       0);
+                gtk_box_reorder_child (GTK_BOX (icon->priv->volume_box),
+                                       GTK_WIDGET (icon->priv->volume_image),
+                                       1);
+        }
+}
+
+static void
+configure_dock_layout (GvcStreamAppletIcon *icon,
+                       gboolean             volume_first)
+{
+        gboolean vertical_panel;
+
+        vertical_panel = icon->priv->orient == MATE_PANEL_APPLET_ORIENT_LEFT ||
+                         icon->priv->orient == MATE_PANEL_APPLET_ORIENT_RIGHT;
+
+        if (icon->priv->player_widget_visible && vertical_panel) {
+                gtk_orientable_set_orientation (GTK_ORIENTABLE (icon->priv->dock_box),
+                                                GTK_ORIENTATION_HORIZONTAL);
+                gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar),
+                                                 GTK_ORIENTATION_VERTICAL);
+                configure_volume_box_layout (icon, GTK_ORIENTATION_VERTICAL);
+
+                if (icon->priv->player_separator != NULL)
+                        gtk_orientable_set_orientation (GTK_ORIENTABLE (icon->priv->player_separator),
+                                                        GTK_ORIENTATION_VERTICAL);
+
+                if (volume_first) {
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box), icon->priv->volume_box, 0);
+                        if (icon->priv->player_separator != NULL)
+                                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                                       icon->priv->player_separator,
+                                                       1);
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                               icon->priv->player_widget,
+                                               2);
+                } else {
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                               icon->priv->player_widget,
+                                               0);
+                        if (icon->priv->player_separator != NULL)
+                                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                                       icon->priv->player_separator,
+                                                       1);
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box), icon->priv->volume_box, 2);
+                }
+
+                gtk_widget_set_size_request (icon->priv->dock, -1, -1);
+                return;
+        }
+
+        gtk_orientable_set_orientation (GTK_ORIENTABLE (icon->priv->dock_box),
+                                        GTK_ORIENTATION_VERTICAL);
+
+        if (icon->priv->player_separator != NULL)
+                gtk_orientable_set_orientation (GTK_ORIENTABLE (icon->priv->player_separator),
+                                                GTK_ORIENTATION_HORIZONTAL);
+
+        if (icon->priv->player_widget_visible && volume_first) {
+                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box), icon->priv->volume_box, 0);
+                if (icon->priv->player_separator != NULL)
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                               icon->priv->player_separator,
+                                               1);
+                if (icon->priv->player_widget != NULL)
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                               icon->priv->player_widget,
+                                               2);
+        } else {
+                if (icon->priv->player_widget != NULL)
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                               icon->priv->player_widget,
+                                               0);
+                if (icon->priv->player_separator != NULL)
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                               icon->priv->player_separator,
+                                               1);
+                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box), icon->priv->volume_box, 2);
+        }
+
+        if (icon->priv->player_widget_visible) {
+                gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar),
+                                                 GTK_ORIENTATION_HORIZONTAL);
+                configure_volume_box_layout (icon, GTK_ORIENTATION_HORIZONTAL);
+                gtk_widget_set_size_request (icon->priv->dock, 336, -1);
+                return;
+        }
+
+        gtk_widget_set_size_request (icon->priv->dock, -1, -1);
+        switch (icon->priv->orient) {
+            case MATE_PANEL_APPLET_ORIENT_LEFT:
+            case MATE_PANEL_APPLET_ORIENT_RIGHT:
+                gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar), GTK_ORIENTATION_HORIZONTAL);
+                configure_volume_box_layout (icon, GTK_ORIENTATION_HORIZONTAL);
+                break;
+            case MATE_PANEL_APPLET_ORIENT_UP:
+            case MATE_PANEL_APPLET_ORIENT_DOWN:
+            default:
+                gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar), GTK_ORIENTATION_VERTICAL);
+                configure_volume_box_layout (icon, GTK_ORIENTATION_VERTICAL);
+        }
+}
 
 static gboolean
 popup_dock (GvcStreamAppletIcon *icon, guint time)
@@ -88,16 +223,7 @@ popup_dock (GvcStreamAppletIcon *icon, guint time)
 
         /* position roughly */
         gtk_window_set_screen (GTK_WINDOW (icon->priv->dock), screen);
-        switch (icon->priv->orient) {
-            case MATE_PANEL_APPLET_ORIENT_LEFT:
-            case MATE_PANEL_APPLET_ORIENT_RIGHT:
-                gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar), GTK_ORIENTATION_HORIZONTAL);
-                break;
-            case MATE_PANEL_APPLET_ORIENT_UP:
-            case MATE_PANEL_APPLET_ORIENT_DOWN:
-            default:
-                gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar), GTK_ORIENTATION_VERTICAL);
-        }
+        configure_dock_layout (icon, FALSE);
 
         display = gdk_screen_get_display (screen);
         monitor_num = gdk_display_get_monitor_at_point (display, allocation.x, allocation.y);
@@ -132,6 +258,7 @@ popup_dock (GvcStreamAppletIcon *icon, guint time)
 
             if (top && left && right)
             {
+                configure_dock_layout (icon, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_BOTTOM, FALSE);
@@ -141,6 +268,7 @@ popup_dock (GvcStreamAppletIcon *icon, guint time)
             }
             if (bottom && left && right)
             {
+                configure_dock_layout (icon, FALSE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_BOTTOM, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, FALSE);
@@ -150,6 +278,7 @@ popup_dock (GvcStreamAppletIcon *icon, guint time)
             }
             if (left && bottom && top && !right)
             {
+                configure_dock_layout (icon, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_RIGHT, FALSE);
@@ -159,6 +288,7 @@ popup_dock (GvcStreamAppletIcon *icon, guint time)
             }
             if (right && bottom && top && !left)
             {
+                configure_dock_layout (icon, FALSE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_RIGHT, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_TOP, TRUE);
                 gtk_layer_set_anchor (GTK_WINDOW (icon->priv->dock), GTK_LAYER_SHELL_EDGE_LEFT, FALSE);
@@ -197,6 +327,12 @@ popup_dock (GvcStreamAppletIcon *icon, guint time)
                 else
                         x = monitor.x + monitor.width - dock_req.width;
         }
+
+        if (icon->priv->orient == MATE_PANEL_APPLET_ORIENT_LEFT ||
+            icon->priv->orient == MATE_PANEL_APPLET_ORIENT_RIGHT)
+                configure_dock_layout (icon, x > allocation.x);
+        else
+                configure_dock_layout (icon, y > allocation.y);
 
         gtk_window_move (GTK_WINDOW (icon->priv->dock), x, y);
 
@@ -244,8 +380,41 @@ on_applet_icon_button_press (GtkWidget           *applet_icon,
                 return TRUE;
         }
 
+        if (event->button == 8 && icon->priv->player != NULL) {
+                gvc_mpris_player_previous (icon->priv->player);
+                return TRUE;
+        }
+
+        if (event->button == 9 && icon->priv->player != NULL) {
+                gvc_mpris_player_next (icon->priv->player);
+                return TRUE;
+        }
+
         /* Middle click acts as mute/unmute */
         if (event->button == 2) {
+                gchar *action = NULL;
+
+                if (icon->priv->applet_settings != NULL)
+                        action = g_settings_get_string (icon->priv->applet_settings, "middle-click-action");
+
+                if (g_strcmp0 (action, "player") == 0) {
+                        if (icon->priv->player != NULL) {
+                                gvc_mpris_player_play_pause (icon->priv->player);
+                                g_free (action);
+                                return TRUE;
+                        }
+                } else if (g_strcmp0 (action, "mute-output") != 0 &&
+                           g_strcmp0 (action, "mute-all") != 0 &&
+                           action != NULL) {
+                        g_free (action);
+                        return FALSE;
+                }
+
+                g_free (action);
+
+                if (icon->priv->control == NULL)
+                        return FALSE;
+
                 gboolean is_muted = mate_mixer_stream_control_get_mute (icon->priv->control);
 
                 mate_mixer_stream_control_set_mute (icon->priv->control, !is_muted);
@@ -298,7 +467,40 @@ on_applet_icon_scroll_event (GtkWidget           *event_box,
                              GdkEventScroll      *event,
                              GvcStreamAppletIcon *icon)
 {
+        if (icon->priv->player != NULL) {
+                if (icon->priv->applet_settings != NULL &&
+                    !g_settings_get_boolean (icon->priv->applet_settings, "horizontal-scroll-controls"))
+                        return gvc_channel_bar_scroll (GVC_CHANNEL_BAR (icon->priv->bar), event->direction);
+
+                if (event->direction == GDK_SCROLL_LEFT) {
+                        gvc_mpris_player_previous (icon->priv->player);
+                        return TRUE;
+                }
+                if (event->direction == GDK_SCROLL_RIGHT) {
+                        gvc_mpris_player_next (icon->priv->player);
+                        return TRUE;
+                }
+        }
+
         return gvc_channel_bar_scroll (GVC_CHANNEL_BAR (icon->priv->bar), event->direction);
+}
+
+void
+gvc_stream_applet_icon_set_applet_settings (GvcStreamAppletIcon *icon,
+                                            GSettings           *settings)
+{
+        g_return_if_fail (GVC_IS_STREAM_APPLET_ICON (icon));
+        g_return_if_fail (settings == NULL || G_IS_SETTINGS (settings));
+
+        if (icon->priv->applet_settings == settings)
+                return;
+
+        g_clear_object (&icon->priv->applet_settings);
+
+        if (settings != NULL)
+                icon->priv->applet_settings = g_object_ref (settings);
+
+        update_icon (icon);
 }
 
 static void
@@ -314,12 +516,123 @@ gvc_icon_release_grab (GvcStreamAppletIcon *icon, GdkEventButton *event)
         gtk_widget_hide (icon->priv->dock);
 }
 
+void
+gvc_stream_applet_icon_set_player_widget (GvcStreamAppletIcon *icon,
+                                          GtkWidget           *player_widget)
+{
+        g_return_if_fail (GVC_IS_STREAM_APPLET_ICON (icon));
+        g_return_if_fail (player_widget == NULL || GTK_IS_WIDGET (player_widget));
+
+        if (icon->priv->player_widget == player_widget)
+                return;
+
+        if (icon->priv->player_widget != NULL) {
+                gtk_container_remove (GTK_CONTAINER (icon->priv->dock_box),
+                                      icon->priv->player_widget);
+                gtk_container_remove (GTK_CONTAINER (icon->priv->dock_box),
+                                      icon->priv->player_separator);
+                icon->priv->player_widget = NULL;
+                icon->priv->player_separator = NULL;
+        }
+
+        if (player_widget != NULL) {
+                GtkWidget *separator;
+
+                icon->priv->player_widget = player_widget;
+                separator = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
+                gtk_widget_set_no_show_all (separator, TRUE);
+                icon->priv->player_separator = separator;
+                gtk_box_pack_start (GTK_BOX (icon->priv->dock_box),
+                                    player_widget,
+                                    FALSE,
+                                    FALSE,
+                                    0);
+                gtk_box_pack_start (GTK_BOX (icon->priv->dock_box),
+                                    separator,
+                                    FALSE,
+                                    FALSE,
+                                    0);
+                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                       player_widget,
+                                       0);
+                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                       separator,
+                                       1);
+        }
+}
+
+static void
+on_mpris_player_tooltip_changed (GvcMprisPlayer      *player,
+                                 GvcStreamAppletIcon *icon)
+{
+        update_icon (icon);
+}
+
+void
+gvc_stream_applet_icon_set_mpris_player (GvcStreamAppletIcon *icon,
+                                         GvcMprisPlayer      *player)
+{
+        g_return_if_fail (GVC_IS_STREAM_APPLET_ICON (icon));
+
+        if (icon->priv->player == player)
+                return;
+
+        if (icon->priv->player != NULL)
+                g_signal_handlers_disconnect_by_data (icon->priv->player, icon);
+
+        g_clear_object (&icon->priv->player);
+
+        if (player != NULL) {
+                icon->priv->player = g_object_ref (player);
+                g_signal_connect (player, "metadata-changed", G_CALLBACK (on_mpris_player_tooltip_changed), icon);
+                g_signal_connect (player, "status-changed", G_CALLBACK (on_mpris_player_tooltip_changed), icon);
+        }
+
+        update_icon (icon);
+}
+
+void
+gvc_stream_applet_icon_set_player_widget_visible (GvcStreamAppletIcon *icon,
+                                                 gboolean             visible)
+{
+        g_return_if_fail (GVC_IS_STREAM_APPLET_ICON (icon));
+
+        icon->priv->player_widget_visible = visible;
+
+        if (icon->priv->player_separator != NULL)
+                gtk_widget_set_visible (icon->priv->player_separator, visible);
+}
+
 static gboolean
 on_dock_button_press (GtkWidget           *widget,
                       GdkEventButton      *event,
                       GvcStreamAppletIcon *icon)
 {
+        GtkAllocation allocation;
+        GtkWidget    *current_grab;
+        gint          dock_x;
+        gint          dock_y;
+        gboolean      inside_dock;
+
         if (event->type == GDK_BUTTON_PRESS) {
+                current_grab = gtk_grab_get_current ();
+                if (current_grab != NULL &&
+                    current_grab != icon->priv->dock &&
+                    !gtk_widget_is_ancestor (current_grab, icon->priv->dock))
+                        return FALSE;
+
+                gtk_widget_get_allocation (icon->priv->dock, &allocation);
+                gdk_window_get_origin (gtk_widget_get_window (icon->priv->dock),
+                                       &dock_x,
+                                       &dock_y);
+                inside_dock = event->x_root >= dock_x &&
+                              event->x_root < dock_x + allocation.width &&
+                              event->y_root >= dock_y &&
+                              event->y_root < dock_y + allocation.height;
+
+                if (inside_dock)
+                        return FALSE;
+
                 gvc_icon_release_grab (icon, event);
                 return TRUE;
         }
@@ -336,6 +649,8 @@ popdown_dock (GvcStreamAppletIcon *icon)
 
         GdkSeat *seat = gdk_display_get_default_seat (display);
         gdk_seat_ungrab (seat);
+        if (gtk_widget_has_grab (icon->priv->dock))
+                gtk_grab_remove (icon->priv->dock);
 
         /* Hide again */
         gtk_widget_unset_state_flags (GTK_WIDGET (icon), GTK_STATE_FLAG_CHECKED);
@@ -346,13 +661,16 @@ popdown_dock (GvcStreamAppletIcon *icon)
 static void
 gvc_icon_grab_notify (GvcStreamAppletIcon *icon, gboolean was_grabbed)
 {
+        GtkWidget *current_grab;
+
         if (was_grabbed != FALSE)
                 return;
 
         if (gtk_widget_has_grab (icon->priv->dock) == FALSE)
                 return;
 
-        if (gtk_widget_is_ancestor (gtk_grab_get_current (), icon->priv->dock))
+        current_grab = gtk_grab_get_current ();
+        if (current_grab != NULL)
                 return;
 
         popdown_dock (icon);
@@ -392,6 +710,12 @@ on_dock_scroll_event (GtkWidget           *widget,
                       GdkEventScroll      *event,
                       GvcStreamAppletIcon *icon)
 {
+        if (icon->priv->player_widget_visible &&
+            icon->priv->player_widget != NULL &&
+            GVC_IS_PLAYER_WIDGET (icon->priv->player_widget) &&
+            gvc_player_widget_scroll_is_seek (GVC_PLAYER_WIDGET (icon->priv->player_widget), event))
+                return gvc_player_widget_handle_seek_scroll (GVC_PLAYER_WIDGET (icon->priv->player_widget), event);
+
         /* Forward event to the applet icon */
         on_applet_icon_scroll_event (NULL, event, icon);
         return TRUE;
@@ -401,14 +725,34 @@ static void
 gvc_stream_applet_icon_set_icon_from_name (GvcStreamAppletIcon *icon,
                                            const gchar *icon_name)
 {
-        GtkIconTheme *icon_theme = gtk_icon_theme_get_default ();
-        gint icon_scale = gtk_widget_get_scale_factor (GTK_WIDGET (icon));
+        GtkIconTheme    *icon_theme;
+        gint             icon_scale;
+        guint            size;
+        cairo_surface_t *surface;
 
-        cairo_surface_t* surface = gtk_icon_theme_load_surface (icon_theme, icon_name,
-                                                                icon->priv->size,
-                                                                icon_scale, NULL,
-                                                                GTK_ICON_LOOKUP_FORCE_SIZE,
-                                                                NULL);
+        if (icon_name == NULL)
+                return;
+
+        size = icon->priv->size;
+        if (size == 0)
+                size = 24;
+
+        icon_theme = gtk_icon_theme_get_default ();
+        icon_scale = gtk_widget_get_scale_factor (GTK_WIDGET (icon));
+
+        surface = gtk_icon_theme_load_surface (icon_theme, icon_name,
+                                               size,
+                                               icon_scale, NULL,
+                                               GTK_ICON_LOOKUP_FORCE_SIZE,
+                                               NULL);
+
+        if (surface == NULL) {
+                gtk_image_set_from_icon_name (GTK_IMAGE (icon->priv->image),
+                                              icon_name,
+                                              GTK_ICON_SIZE_LARGE_TOOLBAR);
+                gtk_image_set_pixel_size (GTK_IMAGE (icon->priv->image), size);
+                return;
+        }
 
         gtk_image_set_from_surface (GTK_IMAGE (icon->priv->image), surface);
         cairo_surface_destroy (surface);
@@ -453,16 +797,16 @@ update_icon (GvcStreamAppletIcon *icon)
         if (flags & MATE_MIXER_STREAM_CONTROL_HAS_DECIBEL)
                 decibel = mate_mixer_stream_control_get_decibel (icon->priv->control);
 
-        /* Apparently applet icon will reset icon even if it doesn't change */
-        if (icon->priv->current_icon != n) {
-                gvc_stream_applet_icon_set_icon_from_name (icon, icon->priv->icon_names[n]);
-                icon->priv->current_icon = n;
-        }
+        gvc_stream_applet_icon_set_icon_from_name (icon, icon->priv->icon_names[n]);
+        icon->priv->current_icon = n;
 
         description = mate_mixer_stream_control_get_label (icon->priv->control);
 
         guint volume_percent = (guint) round (100.0 * volume / normal);
-        if (muted) {
+        if (icon->priv->applet_settings != NULL &&
+            !g_settings_get_boolean (icon->priv->applet_settings, "tooltip-show-volume")) {
+                markup = g_strdup_printf ("<b>%s</b>", icon->priv->display_name);
+        } else if (muted) {
                 markup = g_strdup_printf ("<b>%s: %s %u%%</b>\n<small>%s</small>",
                                           icon->priv->display_name,
                                           _("Muted at"),
@@ -496,6 +840,48 @@ update_icon (GvcStreamAppletIcon *icon)
                                           description);
         }
 
+        if (icon->priv->player != NULL &&
+            icon->priv->applet_settings != NULL &&
+            g_settings_get_boolean (icon->priv->applet_settings, "tooltip-show-player")) {
+                const gchar *title;
+                const gchar *artist;
+                const gchar *identity;
+                gchar       *identity_escaped;
+                gchar       *title_escaped;
+                gchar       *artist_escaped;
+                gchar       *player_markup;
+                gchar       *combined;
+
+                identity = gvc_mpris_player_get_identity (icon->priv->player);
+                title = gvc_mpris_player_get_title (icon->priv->player);
+                artist = gvc_mpris_player_get_artist (icon->priv->player);
+
+                identity_escaped = g_markup_escape_text (identity != NULL ? identity : "", -1);
+                title_escaped = g_markup_escape_text (title != NULL ? title : "", -1);
+                artist_escaped = g_markup_escape_text (artist != NULL ? artist : "", -1);
+
+                if (title_escaped[0] != '\0' && artist_escaped[0] != '\0')
+                        player_markup = g_strdup_printf ("\n<small>%s\n%s - %s</small>",
+                                                         identity_escaped,
+                                                         artist_escaped,
+                                                         title_escaped);
+                else if (title_escaped[0] != '\0')
+                        player_markup = g_strdup_printf ("\n<small>%s\n%s</small>",
+                                                         identity_escaped,
+                                                         title_escaped);
+                else
+                        player_markup = g_strdup_printf ("\n<small>%s</small>",
+                                                         identity_escaped);
+
+                combined = g_strconcat (markup, player_markup, NULL);
+                g_free (markup);
+                g_free (player_markup);
+                g_free (identity_escaped);
+                g_free (title_escaped);
+                g_free (artist_escaped);
+                markup = combined;
+        }
+
         gtk_widget_set_tooltip_markup (GTK_WIDGET (icon), markup);
 
         g_free (markup);
@@ -517,7 +903,8 @@ gvc_stream_applet_icon_set_size (GvcStreamAppletIcon *icon,
                 size = 32;
 
         icon->priv->size = size;
-        gvc_stream_applet_icon_set_icon_from_name (icon, icon->priv->icon_names[icon->priv->current_icon]);
+        if (icon->priv->icon_names != NULL)
+                gvc_stream_applet_icon_set_icon_from_name (icon, icon->priv->icon_names[icon->priv->current_icon]);
 }
 
 void
@@ -594,8 +981,11 @@ gvc_stream_applet_icon_set_control (GvcStreamAppletIcon    *icon,
 {
         g_return_if_fail (GVC_IS_STREAM_APPLET_ICON (icon));
 
-        if (icon->priv->control == control)
+        if (icon->priv->control == control) {
+                if (control != NULL)
+                        update_icon (icon);
                 return;
+        }
 
         if (control != NULL)
                 g_object_ref (control);
@@ -623,7 +1013,6 @@ gvc_stream_applet_icon_set_control (GvcStreamAppletIcon    *icon,
                                   G_CALLBACK (on_stream_control_mute_notify),
                                   icon);
 
-                // XXX when no stream set some default icon and "unset" dock
                 update_icon (icon);
         }
 
@@ -690,7 +1079,9 @@ gvc_stream_applet_icon_dispose (GObject *object)
                 icon->priv->dock = NULL;
         }
 
+        g_clear_object (&icon->priv->player);
         g_clear_object (&icon->priv->control);
+        g_clear_object (&icon->priv->applet_settings);
 
         G_OBJECT_CLASS (gvc_stream_applet_icon_parent_class)->dispose (object);
 }
@@ -811,6 +1202,11 @@ gvc_stream_applet_icon_init (GvcStreamAppletIcon *icon)
         gtk_container_add (GTK_CONTAINER (icon->priv->dock), frame);
 
         icon->priv->bar = gvc_channel_bar_new (NULL);
+        icon->priv->volume_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 4);
+        icon->priv->volume_image = GTK_IMAGE (gtk_image_new_from_icon_name ("multimedia-volume-control",
+                                                                            GTK_ICON_SIZE_MENU));
+        gtk_widget_set_halign (GTK_WIDGET (icon->priv->volume_image), GTK_ALIGN_CENTER);
+        gtk_widget_set_valign (GTK_WIDGET (icon->priv->volume_image), GTK_ALIGN_CENTER);
 
         gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar),
                                          GTK_ORIENTATION_VERTICAL);
@@ -838,11 +1234,18 @@ gvc_stream_applet_icon_init (GvcStreamAppletIcon *icon)
         gtk_widget_set_visual(GTK_WIDGET(toplevel), visual);
 
         box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
+        icon->priv->dock_box = box;
 
         gtk_container_set_border_width (GTK_CONTAINER (box), 2);
         gtk_container_add (GTK_CONTAINER (frame), box);
 
-        gtk_box_pack_start (GTK_BOX (box), icon->priv->bar, TRUE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (icon->priv->volume_box), icon->priv->bar, TRUE, TRUE, 0);
+        gtk_box_pack_start (GTK_BOX (icon->priv->volume_box),
+                            GTK_WIDGET (icon->priv->volume_image),
+                            FALSE,
+                            FALSE,
+                            0);
+        gtk_box_pack_start (GTK_BOX (box), icon->priv->volume_box, TRUE, FALSE, 0);
 
         g_signal_connect (gtk_settings_get_default (),
                           "notify::gtk-icon-theme-name",
@@ -865,6 +1268,7 @@ gvc_stream_applet_icon_finalize (GObject *object)
                                               icon);
 
         g_clear_object (&icon->priv->sound_settings);
+        g_clear_object (&icon->priv->applet_settings);
 
         G_OBJECT_CLASS (gvc_stream_applet_icon_parent_class)->finalize (object);
 }

--- a/mate-volume-control/gvc-stream-applet-icon.h
+++ b/mate-volume-control/gvc-stream-applet-icon.h
@@ -26,7 +26,10 @@
 
 #include <glib.h>
 #include <glib-object.h>
+#include <gio/gio.h>
 #include <libmatemixer/matemixer.h>
+
+#include "gvc-mpris-player.h"
 
 G_BEGIN_DECLS
 
@@ -77,6 +80,15 @@ void                  gvc_stream_applet_icon_set_mute         (GvcStreamAppletIc
                                                                gboolean mute);
 
 void                  gvc_stream_applet_icon_volume_control   (GvcStreamAppletIcon *icon);
+
+void                  gvc_stream_applet_icon_set_player_widget (GvcStreamAppletIcon *icon,
+                                                                GtkWidget           *player_widget);
+void                  gvc_stream_applet_icon_set_mpris_player  (GvcStreamAppletIcon *icon,
+                                                                GvcMprisPlayer      *player);
+void                  gvc_stream_applet_icon_set_player_widget_visible (GvcStreamAppletIcon *icon,
+                                                                        gboolean             visible);
+void                  gvc_stream_applet_icon_set_applet_settings (GvcStreamAppletIcon *icon,
+                                                                  GSettings           *settings);
 
 G_END_DECLS
 

--- a/mate-volume-control/gvc-stream-status-icon.c
+++ b/mate-volume-control/gvc-stream-status-icon.c
@@ -22,6 +22,7 @@
 
 #include <glib.h>
 #include <glib/gi18n.h>
+#include <gio/gdesktopappinfo.h>
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
 
@@ -32,18 +33,39 @@
 #include <libmate-desktop/mate-image-menu-item.h>
 
 #include "gvc-channel-bar.h"
+#include "gvc-mpris-manager.h"
+#include "gvc-mpris-player.h"
+#include "gvc-player-widget.h"
 #include "gvc-stream-status-icon.h"
 
 struct _GvcStreamStatusIconPrivate
 {
-        GSettings       *sound_settings;
-        gchar          **icon_names;
-        GtkWidget       *dock;
-        GtkWidget       *bar;
-        guint            current_icon;
-        gchar           *display_name;
+        GSettings              *sound_settings;
+        GSettings              *applet_settings;
+        gchar                 **icon_names;
+        GtkWidget              *dock;
+        GtkWidget              *dock_box;
+        GtkWidget              *player_widget;
+        GtkWidget              *player_separator;
+        GtkWidget              *volume_box;
+        GtkImage               *volume_image;
+        GtkWidget              *bar;
+        GvcMprisPlayer         *player;
+        gboolean                player_widget_visible;
+        guint                   current_icon;
+        gchar                  *display_name;
         MateMixerStreamControl *control;
+        GvcMprisManager        *mpris_manager;
+        MateMixerContext       *mixer_context;
 };
+
+enum
+{
+        PLAYER_SELECTED,
+        N_SIGNALS
+};
+
+static guint signals[N_SIGNALS] = { 0 };
 
 enum
 {
@@ -56,9 +78,130 @@ enum
 
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
-static void gvc_stream_status_icon_finalize   (GObject                  *object);
+static void gvc_stream_status_icon_finalize (GObject *object);
+static void update_icon                     (GvcStreamStatusIcon *icon);
 
 G_DEFINE_TYPE_WITH_PRIVATE (GvcStreamStatusIcon, gvc_stream_status_icon, GTK_TYPE_STATUS_ICON)
+
+static void
+configure_volume_box_layout (GvcStreamStatusIcon *icon,
+                             GtkOrientation       orientation)
+{
+        if (icon->priv->volume_box == NULL ||
+            icon->priv->volume_image == NULL)
+                return;
+
+        gtk_orientable_set_orientation (GTK_ORIENTABLE (icon->priv->volume_box),
+                                        orientation);
+
+        if (orientation == GTK_ORIENTATION_HORIZONTAL) {
+                gtk_box_reorder_child (GTK_BOX (icon->priv->volume_box),
+                                       GTK_WIDGET (icon->priv->volume_image),
+                                       0);
+                gtk_box_reorder_child (GTK_BOX (icon->priv->volume_box),
+                                       icon->priv->bar,
+                                       1);
+        } else {
+                gtk_box_reorder_child (GTK_BOX (icon->priv->volume_box),
+                                       icon->priv->bar,
+                                       0);
+                gtk_box_reorder_child (GTK_BOX (icon->priv->volume_box),
+                                       GTK_WIDGET (icon->priv->volume_image),
+                                       1);
+        }
+}
+
+static void
+configure_dock_layout (GvcStreamStatusIcon *icon,
+                       GtkOrientation       tray_orientation,
+                       gboolean             volume_first)
+{
+        gboolean vertical_tray;
+
+        vertical_tray = tray_orientation == GTK_ORIENTATION_VERTICAL;
+
+        if (icon->priv->player_widget_visible && vertical_tray) {
+                gtk_orientable_set_orientation (GTK_ORIENTABLE (icon->priv->dock_box),
+                                                GTK_ORIENTATION_HORIZONTAL);
+                gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar),
+                                                 GTK_ORIENTATION_VERTICAL);
+                configure_volume_box_layout (icon, GTK_ORIENTATION_VERTICAL);
+
+                if (icon->priv->player_separator != NULL)
+                        gtk_orientable_set_orientation (GTK_ORIENTABLE (icon->priv->player_separator),
+                                                        GTK_ORIENTATION_VERTICAL);
+
+                if (volume_first) {
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box), icon->priv->volume_box, 0);
+                        if (icon->priv->player_separator != NULL)
+                                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                                       icon->priv->player_separator,
+                                                       1);
+                        if (icon->priv->player_widget != NULL)
+                                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                                       icon->priv->player_widget,
+                                                       2);
+                } else {
+                        if (icon->priv->player_widget != NULL)
+                                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                                       icon->priv->player_widget,
+                                                       0);
+                        if (icon->priv->player_separator != NULL)
+                                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                                       icon->priv->player_separator,
+                                                       1);
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box), icon->priv->volume_box, 2);
+                }
+
+                gtk_widget_set_size_request (icon->priv->dock, -1, -1);
+                return;
+        }
+
+        gtk_orientable_set_orientation (GTK_ORIENTABLE (icon->priv->dock_box),
+                                        GTK_ORIENTATION_VERTICAL);
+
+        if (icon->priv->player_separator != NULL)
+                gtk_orientable_set_orientation (GTK_ORIENTABLE (icon->priv->player_separator),
+                                                GTK_ORIENTATION_HORIZONTAL);
+
+        if (icon->priv->player_widget_visible && volume_first) {
+                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box), icon->priv->volume_box, 0);
+                if (icon->priv->player_separator != NULL)
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                               icon->priv->player_separator,
+                                               1);
+                if (icon->priv->player_widget != NULL)
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                               icon->priv->player_widget,
+                                               2);
+        } else {
+                if (icon->priv->player_widget != NULL)
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                               icon->priv->player_widget,
+                                               0);
+                if (icon->priv->player_separator != NULL)
+                        gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                               icon->priv->player_separator,
+                                               1);
+                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box), icon->priv->volume_box, 2);
+        }
+
+        if (icon->priv->player_widget_visible) {
+                gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar),
+                                                 GTK_ORIENTATION_HORIZONTAL);
+                configure_volume_box_layout (icon, GTK_ORIENTATION_HORIZONTAL);
+                gtk_widget_set_size_request (icon->priv->dock, 336, -1);
+                return;
+        }
+
+        gtk_widget_set_size_request (icon->priv->dock, -1, -1);
+        gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar),
+                                         vertical_tray ? GTK_ORIENTATION_HORIZONTAL
+                                                       : GTK_ORIENTATION_VERTICAL);
+        configure_volume_box_layout (icon,
+                                     vertical_tray ? GTK_ORIENTATION_HORIZONTAL
+                                                   : GTK_ORIENTATION_VERTICAL);
+}
 
 static gboolean
 popup_dock (GvcStreamStatusIcon *icon, guint time)
@@ -79,17 +222,28 @@ popup_dock (GvcStreamStatusIcon *icon, guint time)
                                           &screen,
                                           &area,
                                           &orientation) == FALSE) {
+                /* Some platforms (notably Wayland / StatusNotifierItem hosts)
+                 * don't expose tray geometry; position the dock near the
+                 * pointer as a best-effort fallback. */
+                GdkDevice *pointer;
+                GdkSeat   *seat;
+
                 g_warning ("Unable to determine geometry of status icon");
-                return FALSE;
+
+                screen = gdk_screen_get_default ();
+                seat = gdk_display_get_default_seat (gdk_screen_get_display (screen));
+                pointer = gdk_seat_get_pointer (seat);
+                gdk_device_get_position (pointer, NULL, &area.x, &area.y);
+                area.width = 1;
+                area.height = 1;
+                orientation = GTK_ORIENTATION_HORIZONTAL;
         }
 
-        /* position roughly */
         gtk_window_set_screen (GTK_WINDOW (icon->priv->dock), screen);
-        gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar),
-                                         1 - orientation);
 
         monitor_num = gdk_display_get_monitor_at_point (gdk_screen_get_display (screen), area.x, area.y);
         gdk_monitor_get_geometry (monitor_num, &monitor);
+        configure_dock_layout (icon, orientation, FALSE);
 
         gtk_container_foreach (GTK_CONTAINER (icon->priv->dock),
                                (GtkCallback) gtk_widget_show_all, NULL);
@@ -116,6 +270,11 @@ popup_dock (GvcStreamStatusIcon *icon, guint time)
                 else
                         x = monitor.x + monitor.width - dock_req.width;
         }
+
+        if (orientation == GTK_ORIENTATION_VERTICAL)
+                configure_dock_layout (icon, orientation, x > area.x);
+        else
+                configure_dock_layout (icon, orientation, y > area.y);
 
         gtk_window_move (GTK_WINDOW (icon->priv->dock), x, y);
 
@@ -164,11 +323,42 @@ on_status_icon_button_press (GtkStatusIcon       *status_icon,
                              GdkEventButton      *event,
                              GvcStreamStatusIcon *icon)
 {
-        /* Middle click acts as mute/unmute */
-        if (event->button == 2) {
-                gboolean is_muted = mate_mixer_stream_control_get_mute (icon->priv->control);
+        if (event->button == 8 && icon->priv->player != NULL) {
+                gvc_mpris_player_previous (icon->priv->player);
+                return TRUE;
+        }
 
-                mate_mixer_stream_control_set_mute (icon->priv->control, !is_muted);
+        if (event->button == 9 && icon->priv->player != NULL) {
+                gvc_mpris_player_next (icon->priv->player);
+                return TRUE;
+        }
+
+        if (event->button == 2) {
+                gchar *action = NULL;
+
+                if (icon->priv->applet_settings != NULL)
+                        action = g_settings_get_string (icon->priv->applet_settings, "middle-click-action");
+
+                if (g_strcmp0 (action, "player") == 0) {
+                        if (icon->priv->player != NULL) {
+                                gvc_mpris_player_play_pause (icon->priv->player);
+                                g_free (action);
+                                return TRUE;
+                        }
+                } else if (action != NULL &&
+                           g_strcmp0 (action, "mute-output") != 0 &&
+                           g_strcmp0 (action, "mute-all") != 0) {
+                        g_free (action);
+                        return FALSE;
+                }
+
+                g_free (action);
+
+                if (icon->priv->control == NULL)
+                        return FALSE;
+
+                mate_mixer_stream_control_set_mute (icon->priv->control,
+                                                    !mate_mixer_stream_control_get_mute (icon->priv->control));
                 return TRUE;
         }
         return FALSE;
@@ -209,62 +399,275 @@ on_menu_activate_open_volume_control (GtkMenuItem         *item,
 }
 
 static void
+on_menu_show_player_toggled (GtkCheckMenuItem    *item,
+                             GvcStreamStatusIcon *icon)
+{
+        if (icon->priv->applet_settings == NULL)
+                return;
+
+        g_settings_set_boolean (icon->priv->applet_settings,
+                                "show-player-controls",
+                                gtk_check_menu_item_get_active (item));
+}
+
+static void
+on_player_menu_item_toggled (GtkCheckMenuItem    *item,
+                             GvcStreamStatusIcon *icon)
+{
+        GvcMprisPlayer *player;
+
+        if (!gtk_check_menu_item_get_active (item))
+                return;
+
+        player = g_object_get_data (G_OBJECT (item), "gvc-player");
+        g_signal_emit (icon, signals[PLAYER_SELECTED], 0, player);
+}
+
+static void
+on_stream_menu_item_toggled (GtkCheckMenuItem    *item,
+                             GvcStreamStatusIcon *icon)
+{
+        MateMixerStream    *stream;
+        MateMixerDirection  direction;
+
+        if (!gtk_check_menu_item_get_active (item))
+                return;
+
+        stream = g_object_get_data (G_OBJECT (item), "gvc-stream");
+        if (stream == NULL || icon->priv->mixer_context == NULL)
+                return;
+
+        direction = mate_mixer_stream_get_direction (stream);
+        if (direction == MATE_MIXER_DIRECTION_OUTPUT)
+                mate_mixer_context_set_default_output_stream (icon->priv->mixer_context, stream);
+        else if (direction == MATE_MIXER_DIRECTION_INPUT)
+                mate_mixer_context_set_default_input_stream (icon->priv->mixer_context, stream);
+}
+
+static void
+on_launch_player_menu_item_activate (GtkMenuItem         *item,
+                                     GvcStreamStatusIcon *icon)
+{
+        const gchar     *desktop_entry;
+        GDesktopAppInfo *app_info;
+        GError          *error = NULL;
+
+        desktop_entry = g_object_get_data (G_OBJECT (item), "desktop-entry");
+        if (desktop_entry == NULL)
+                return;
+
+        app_info = g_desktop_app_info_new (desktop_entry);
+        if (app_info == NULL && !g_str_has_suffix (desktop_entry, ".desktop")) {
+                gchar *desktop_id;
+
+                desktop_id = g_strconcat (desktop_entry, ".desktop", NULL);
+                app_info = g_desktop_app_info_new (desktop_id);
+                g_free (desktop_id);
+        }
+
+        if (app_info == NULL)
+                return;
+
+        g_app_info_launch (G_APP_INFO (app_info), NULL, NULL, &error);
+        if (error != NULL)
+                g_error_free (error);
+
+        g_object_unref (app_info);
+}
+
+static GtkWidget *
+new_image_menu_item (const gchar *label,
+                     const gchar *icon_name)
+{
+        GtkWidget *item;
+        GtkWidget *image;
+
+        item = mate_image_menu_item_new_with_label (label);
+        image = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU);
+        mate_image_menu_item_set_image (MATE_IMAGE_MENU_ITEM (item), image);
+
+        return item;
+}
+
+static void
+append_stream_menu_items (GvcStreamStatusIcon *icon,
+                          GtkWidget           *submenu,
+                          MateMixerDirection   direction)
+{
+        const GList *streams;
+        GSList      *group = NULL;
+
+        if (icon->priv->mixer_context == NULL)
+                return;
+
+        streams = mate_mixer_context_list_streams (icon->priv->mixer_context);
+        while (streams != NULL) {
+                MateMixerStream *stream = MATE_MIXER_STREAM (streams->data);
+
+                if (mate_mixer_stream_get_direction (stream) == direction) {
+                        GtkWidget       *item;
+                        MateMixerStream *active;
+                        const gchar     *label;
+
+                        active = direction == MATE_MIXER_DIRECTION_OUTPUT ?
+                                mate_mixer_context_get_default_output_stream (icon->priv->mixer_context) :
+                                mate_mixer_context_get_default_input_stream (icon->priv->mixer_context);
+                        label = mate_mixer_stream_get_label (stream);
+                        if (label == NULL || label[0] == '\0')
+                                label = mate_mixer_stream_get_name (stream);
+
+                        item = gtk_radio_menu_item_new_with_label (group, label);
+                        group = gtk_radio_menu_item_get_group (GTK_RADIO_MENU_ITEM (item));
+                        gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (item), stream == active);
+                        g_object_set_data_full (G_OBJECT (item), "gvc-stream", g_object_ref (stream), g_object_unref);
+                        g_signal_connect (item, "toggled", G_CALLBACK (on_stream_menu_item_toggled), icon);
+                        gtk_menu_shell_append (GTK_MENU_SHELL (submenu), item);
+                }
+
+                streams = streams->next;
+        }
+}
+
+static void
 on_status_icon_popup_menu (GtkStatusIcon       *status_icon,
                            guint                button,
                            guint                activate_time,
                            GvcStreamStatusIcon *icon)
 {
-        GtkWidget *menu;
-        GtkWidget *item;
-        GtkWidget *image;
+        GtkWidget       *menu;
+        GtkWidget       *item;
+        GtkWidget       *image;
+        GtkWidget       *submenu;
+        GtkWidget       *toplevel;
+        GtkStyleContext *context;
+        GdkScreen       *screen;
+        GdkVisual       *visual;
+        GSList          *player_group = NULL;
         g_autofree char *label = NULL;
 
         menu = gtk_menu_new ();
 
-        /* Set up theme and transparency support */
-        GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
-        /* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
-        GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
-        GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
-        gtk_widget_set_visual(GTK_WIDGET(toplevel), visual);
-        /* Set menu and it's toplevel window to follow panel theme */
-        GtkStyleContext *context;
-        context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
-        gtk_style_context_add_class(context,"gnome-panel-menu-bar");
-        gtk_style_context_add_class(context,"mate-panel-menu-bar");
+        toplevel = gtk_widget_get_toplevel (menu);
+        screen = gtk_widget_get_screen (GTK_WIDGET (toplevel));
+        visual = gdk_screen_get_rgba_visual (screen);
+        gtk_widget_set_visual (GTK_WIDGET (toplevel), visual);
+        context = gtk_widget_get_style_context (GTK_WIDGET (toplevel));
+        gtk_style_context_add_class (context, "gnome-panel-menu-bar");
+        gtk_style_context_add_class (context, "mate-panel-menu-bar");
 
-        if (mate_mixer_stream_control_get_mute (icon->priv->control))
-        {
+        if (icon->priv->mpris_manager != NULL) {
+                GList *players;
+                GList *l;
+
+                item = new_image_menu_item (_("Media Players"), "applications-multimedia");
+                submenu = gtk_menu_new ();
+                players = gvc_mpris_manager_get_players (icon->priv->mpris_manager);
+                for (l = players; l != NULL; l = l->next) {
+                        GvcMprisPlayer *player = GVC_MPRIS_PLAYER (l->data);
+                        GtkWidget      *player_item;
+                        const gchar    *plabel;
+
+                        if (!gvc_mpris_player_is_ready (player))
+                                continue;
+
+                        plabel = gvc_mpris_player_get_identity (player);
+                        player_item = gtk_radio_menu_item_new_with_label (player_group,
+                                                                          plabel != NULL && plabel[0] != '\0' ?
+                                                                          plabel :
+                                                                          gvc_mpris_player_get_bus_name (player));
+                        player_group = gtk_radio_menu_item_get_group (GTK_RADIO_MENU_ITEM (player_item));
+                        gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (player_item), player == icon->priv->player);
+                        g_object_set_data_full (G_OBJECT (player_item), "gvc-player", g_object_ref (player), g_object_unref);
+                        g_signal_connect (player_item, "toggled", G_CALLBACK (on_player_menu_item_toggled), icon);
+                        gtk_menu_shell_append (GTK_MENU_SHELL (submenu), player_item);
+                }
+                g_list_free (players);
+                gtk_menu_item_set_submenu (GTK_MENU_ITEM (item), submenu);
+                gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+        }
+
+        if (icon->priv->applet_settings != NULL) {
+                gchar **known;
+                gint    i;
+
+                item = new_image_menu_item (_("Launch Player"), "applications-multimedia");
+                submenu = gtk_menu_new ();
+                known = g_settings_get_strv (icon->priv->applet_settings, "known-players");
+                for (i = 0; known != NULL && known[i] != NULL; i++) {
+                        GtkWidget *launcher_item;
+
+                        launcher_item = gtk_menu_item_new_with_label (known[i]);
+                        g_object_set_data_full (G_OBJECT (launcher_item), "desktop-entry", g_strdup (known[i]), g_free);
+                        g_signal_connect (launcher_item, "activate", G_CALLBACK (on_launch_player_menu_item_activate), icon);
+                        gtk_menu_shell_append (GTK_MENU_SHELL (submenu), launcher_item);
+                }
+                g_strfreev (known);
+                gtk_menu_item_set_submenu (GTK_MENU_ITEM (item), submenu);
+                gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+        }
+
+        if (icon->priv->mixer_context != NULL) {
+                item = new_image_menu_item (_("Output Device"), "audio-speakers");
+                submenu = gtk_menu_new ();
+                append_stream_menu_items (icon, submenu, MATE_MIXER_DIRECTION_OUTPUT);
+                gtk_menu_item_set_submenu (GTK_MENU_ITEM (item), submenu);
+                gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+                item = new_image_menu_item (_("Input Device"), "audio-input-microphone");
+                submenu = gtk_menu_new ();
+                append_stream_menu_items (icon, submenu, MATE_MIXER_DIRECTION_INPUT);
+                gtk_menu_item_set_submenu (GTK_MENU_ITEM (item), submenu);
+                gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+        }
+
+        if (icon->priv->mpris_manager != NULL || icon->priv->mixer_context != NULL) {
+                item = gtk_separator_menu_item_new ();
+                gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+        }
+
+        if (mate_mixer_stream_control_get_mute (icon->priv->control)) {
                 label = g_strdup_printf ("%s %s", _("Unmute"), icon->priv->display_name);
-                /* Set icon to medium*/
-                image = gtk_image_new_from_icon_name(icon->priv->icon_names[2], GTK_ICON_SIZE_MENU);
-        }
-        else
-        {
+                image = gtk_image_new_from_icon_name (icon->priv->icon_names[2], GTK_ICON_SIZE_MENU);
+        } else {
                 label = g_strdup_printf ("%s %s", _("Mute"), icon->priv->display_name);
-                /* Set icon to muted*/
-                image = gtk_image_new_from_icon_name(icon->priv->icon_names[0], GTK_ICON_SIZE_MENU);
+                image = gtk_image_new_from_icon_name (icon->priv->icon_names[0], GTK_ICON_SIZE_MENU);
         }
-        item = mate_image_menu_item_new_with_mnemonic(label);
+        item = mate_image_menu_item_new_with_mnemonic (label);
         mate_image_menu_item_set_image (MATE_IMAGE_MENU_ITEM (item), image);
         g_signal_connect (G_OBJECT (item),
                           "activate",
                           G_CALLBACK (on_menu_mute_toggled),
                           icon);
-
         gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
 
-        item = mate_image_menu_item_new_with_mnemonic (_("_Sound Preferences"));
-        image = gtk_image_new_from_icon_name ("multimedia-volume-control",
-                                              GTK_ICON_SIZE_MENU);
-        mate_image_menu_item_set_image (MATE_IMAGE_MENU_ITEM (item), image);
+        if (icon->priv->applet_settings != NULL) {
+                item = gtk_separator_menu_item_new ();
+                gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
 
+                item = gtk_check_menu_item_new_with_mnemonic (_("Show _media player controls"));
+                gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (item),
+                                                g_settings_get_boolean (icon->priv->applet_settings,
+                                                                        "show-player-controls"));
+                g_signal_connect (G_OBJECT (item),
+                                  "toggled",
+                                  G_CALLBACK (on_menu_show_player_toggled),
+                                  icon);
+                gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+                item = gtk_separator_menu_item_new ();
+                gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+        }
+
+        item = mate_image_menu_item_new_with_mnemonic (_("_Sound Preferences"));
+        image = gtk_image_new_from_icon_name ("multimedia-volume-control", GTK_ICON_SIZE_MENU);
+        mate_image_menu_item_set_image (MATE_IMAGE_MENU_ITEM (item), image);
         g_signal_connect (G_OBJECT (item),
                           "activate",
                           G_CALLBACK (on_menu_activate_open_volume_control),
                           icon);
-
         gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+
+        g_signal_connect (menu, "selection-done", G_CALLBACK (gtk_widget_destroy), NULL);
 
         gtk_widget_show_all (menu);
         gtk_menu_popup (GTK_MENU (menu),
@@ -281,6 +684,21 @@ on_status_icon_scroll_event (GtkStatusIcon       *status_icon,
                              GdkEventScroll      *event,
                              GvcStreamStatusIcon *icon)
 {
+        if (icon->priv->player != NULL) {
+                if (icon->priv->applet_settings != NULL &&
+                    !g_settings_get_boolean (icon->priv->applet_settings, "horizontal-scroll-controls"))
+                        return gvc_channel_bar_scroll (GVC_CHANNEL_BAR (icon->priv->bar), event->direction);
+
+                if (event->direction == GDK_SCROLL_LEFT) {
+                        gvc_mpris_player_previous (icon->priv->player);
+                        return TRUE;
+                }
+                if (event->direction == GDK_SCROLL_RIGHT) {
+                        gvc_mpris_player_next (icon->priv->player);
+                        return TRUE;
+                }
+        }
+
         return gvc_channel_bar_scroll (GVC_CHANNEL_BAR (icon->priv->bar), event->direction);
 }
 
@@ -288,11 +706,10 @@ static void
 gvc_icon_release_grab (GvcStreamStatusIcon *icon, GdkEventButton *event)
 {
         GdkDisplay *display = gtk_widget_get_display (icon->priv->dock);
-        GdkSeat *seat = gdk_display_get_default_seat (display);
+        GdkSeat    *seat = gdk_display_get_default_seat (display);
         gdk_seat_ungrab (seat);
         gtk_grab_remove (icon->priv->dock);
 
-        /* Hide again */
         gtk_widget_hide (icon->priv->dock);
 }
 
@@ -301,7 +718,31 @@ on_dock_button_press (GtkWidget           *widget,
                       GdkEventButton      *event,
                       GvcStreamStatusIcon *icon)
 {
+        GtkAllocation allocation;
+        GtkWidget    *current_grab;
+        gint          dock_x;
+        gint          dock_y;
+        gboolean      inside_dock;
+
         if (event->type == GDK_BUTTON_PRESS) {
+                current_grab = gtk_grab_get_current ();
+                if (current_grab != NULL &&
+                    current_grab != icon->priv->dock &&
+                    !gtk_widget_is_ancestor (current_grab, icon->priv->dock))
+                        return FALSE;
+
+                gtk_widget_get_allocation (icon->priv->dock, &allocation);
+                gdk_window_get_origin (gtk_widget_get_window (icon->priv->dock),
+                                       &dock_x,
+                                       &dock_y);
+                inside_dock = event->x_root >= dock_x &&
+                              event->x_root < dock_x + allocation.width &&
+                              event->y_root >= dock_y &&
+                              event->y_root < dock_y + allocation.height;
+
+                if (inside_dock)
+                        return FALSE;
+
                 gvc_icon_release_grab (icon, event);
                 return TRUE;
         }
@@ -313,13 +754,15 @@ static void
 popdown_dock (GvcStreamStatusIcon *icon)
 {
         GdkDisplay *display;
+        GdkSeat    *seat;
 
         display = gtk_widget_get_display (icon->priv->dock);
 
-        GdkSeat *seat = gdk_display_get_default_seat (display);
+        seat = gdk_display_get_default_seat (display);
         gdk_seat_ungrab (seat);
+        if (gtk_widget_has_grab (icon->priv->dock))
+                gtk_grab_remove (icon->priv->dock);
 
-        /* Hide again */
         gtk_widget_hide (icon->priv->dock);
 }
 
@@ -327,13 +770,16 @@ popdown_dock (GvcStreamStatusIcon *icon)
 static void
 gvc_icon_grab_notify (GvcStreamStatusIcon *icon, gboolean was_grabbed)
 {
+        GtkWidget *current_grab;
+
         if (was_grabbed != FALSE)
                 return;
 
         if (gtk_widget_has_grab (icon->priv->dock) == FALSE)
                 return;
 
-        if (gtk_widget_is_ancestor (gtk_grab_get_current (), icon->priv->dock))
+        current_grab = gtk_grab_get_current ();
+        if (current_grab != NULL)
                 return;
 
         popdown_dock (icon);
@@ -373,7 +819,12 @@ on_dock_scroll_event (GtkWidget           *widget,
                       GdkEventScroll      *event,
                       GvcStreamStatusIcon *icon)
 {
-        /* Forward event to the status icon */
+        if (icon->priv->player_widget_visible &&
+            icon->priv->player_widget != NULL &&
+            GVC_IS_PLAYER_WIDGET (icon->priv->player_widget) &&
+            gvc_player_widget_scroll_is_seek (GVC_PLAYER_WIDGET (icon->priv->player_widget), event))
+                return gvc_player_widget_handle_seek_scroll (GVC_PLAYER_WIDGET (icon->priv->player_widget), event);
+
         on_status_icon_scroll_event (NULL, event, icon);
         return TRUE;
 }
@@ -381,23 +832,21 @@ on_dock_scroll_event (GtkWidget           *widget,
 static void
 update_icon (GvcStreamStatusIcon *icon)
 {
-        guint                volume = 0;
-        guint                volume_percent = 0;
-        gdouble              decibel = 0;
-        guint                normal = 0;
-        gboolean             muted = FALSE;
-        guint                n = 0;
-        gchar               *markup;
-        const gchar         *description;
+        guint                       volume = 0;
+        guint                       volume_percent = 0;
+        gdouble                     decibel = 0;
+        guint                       normal = 0;
+        gboolean                    muted = FALSE;
+        guint                       n = 0;
+        gchar                      *markup;
+        const gchar                *description;
         MateMixerStreamControlFlags flags;
 
         if (icon->priv->control == NULL) {
-                /* Do not bother creating a tooltip for an unusable icon as it
-                 * has no practical use */
                 gtk_status_icon_set_has_tooltip (GTK_STATUS_ICON (icon), FALSE);
                 return;
-        } else
-                gtk_status_icon_set_has_tooltip (GTK_STATUS_ICON (icon), TRUE);
+        }
+        gtk_status_icon_set_has_tooltip (GTK_STATUS_ICON (icon), TRUE);
 
         flags = mate_mixer_stream_control_get_flags (icon->priv->control);
 
@@ -410,7 +859,7 @@ update_icon (GvcStreamStatusIcon *icon)
 
                 /* Select an icon, they are expected to be sorted, the lowest index being
                  * the mute icon and the rest being volume increments */
-                if (volume == 0 || muted)
+                if (volume <= 0 || muted)
                         n = 0;
                 else
                         n = CLAMP (3 * volume / normal + 1, 1, 3);
@@ -418,19 +867,19 @@ update_icon (GvcStreamStatusIcon *icon)
         if (flags & MATE_MIXER_STREAM_CONTROL_HAS_DECIBEL)
                 decibel = mate_mixer_stream_control_get_decibel (icon->priv->control);
 
-        /* Apparently status icon will reset icon even if it doesn't change */
-        if (icon->priv->current_icon != n) {
-                gtk_status_icon_set_from_icon_name (GTK_STATUS_ICON (icon),
-                                                    icon->priv->icon_names[n]);
-                icon->priv->current_icon = n;
-        }
+        gtk_status_icon_set_from_icon_name (GTK_STATUS_ICON (icon),
+                                            icon->priv->icon_names[n]);
+        icon->priv->current_icon = n;
 
         description = mate_mixer_stream_control_get_label (icon->priv->control);
 
         if (normal != 0)
                 volume_percent = (guint) (100.0 * ((double) volume) / ((double) normal));
 
-        if (muted) {
+        if (icon->priv->applet_settings != NULL &&
+            !g_settings_get_boolean (icon->priv->applet_settings, "tooltip-show-volume")) {
+                markup = g_strdup_printf ("<b>%s</b>", icon->priv->display_name);
+        } else if (muted) {
                 markup = g_strdup_printf ("<b>%s: %s %u%%</b>\n<small>%s</small>",
                                           icon->priv->display_name,
                                           _("Muted at"),
@@ -464,6 +913,48 @@ update_icon (GvcStreamStatusIcon *icon)
                                           description);
         }
 
+        if (icon->priv->player != NULL &&
+            icon->priv->applet_settings != NULL &&
+            g_settings_get_boolean (icon->priv->applet_settings, "tooltip-show-player")) {
+                const gchar *title;
+                const gchar *artist;
+                const gchar *identity;
+                gchar       *identity_escaped;
+                gchar       *title_escaped;
+                gchar       *artist_escaped;
+                gchar       *player_markup;
+                gchar       *combined;
+
+                identity = gvc_mpris_player_get_identity (icon->priv->player);
+                title = gvc_mpris_player_get_title (icon->priv->player);
+                artist = gvc_mpris_player_get_artist (icon->priv->player);
+
+                identity_escaped = g_markup_escape_text (identity != NULL ? identity : "", -1);
+                title_escaped = g_markup_escape_text (title != NULL ? title : "", -1);
+                artist_escaped = g_markup_escape_text (artist != NULL ? artist : "", -1);
+
+                if (title_escaped[0] != '\0' && artist_escaped[0] != '\0')
+                        player_markup = g_strdup_printf ("\n<small>%s\n%s - %s</small>",
+                                                         identity_escaped,
+                                                         artist_escaped,
+                                                         title_escaped);
+                else if (title_escaped[0] != '\0')
+                        player_markup = g_strdup_printf ("\n<small>%s\n%s</small>",
+                                                         identity_escaped,
+                                                         title_escaped);
+                else
+                        player_markup = g_strdup_printf ("\n<small>%s</small>",
+                                                         identity_escaped);
+
+                combined = g_strconcat (markup, player_markup, NULL);
+                g_free (markup);
+                g_free (player_markup);
+                g_free (identity_escaped);
+                g_free (title_escaped);
+                g_free (artist_escaped);
+                markup = combined;
+        }
+
         gtk_status_icon_set_tooltip_markup (GTK_STATUS_ICON (icon), markup);
 
         g_free (markup);
@@ -485,8 +976,6 @@ gvc_stream_status_icon_set_icon_names (GvcStreamStatusIcon  *icon,
 
         icon->priv->icon_names = g_strdupv ((gchar **) names);
 
-        /* Set the first icon as the initial one, the icon may be immediately
-         * updated or not depending on whether a stream is available */
         gtk_status_icon_set_from_icon_name (GTK_STATUS_ICON (icon), names[0]);
         update_icon (icon);
 
@@ -494,17 +983,17 @@ gvc_stream_status_icon_set_icon_names (GvcStreamStatusIcon  *icon,
 }
 
 static void
-on_stream_control_volume_notify (MateMixerStreamControl     *control,
-                         GParamSpec          *pspec,
-                         GvcStreamStatusIcon *icon)
+on_stream_control_volume_notify (MateMixerStreamControl *control,
+                                 GParamSpec             *pspec,
+                                 GvcStreamStatusIcon    *icon)
 {
         update_icon (icon);
 }
 
 static void
-on_stream_control_mute_notify (MateMixerStreamControl     *control,
-                       GParamSpec          *pspec,
-                       GvcStreamStatusIcon *icon)
+on_stream_control_mute_notify (MateMixerStreamControl *control,
+                               GParamSpec             *pspec,
+                               GvcStreamStatusIcon    *icon)
 {
         update_icon (icon);
 }
@@ -529,8 +1018,11 @@ gvc_stream_status_icon_set_control (GvcStreamStatusIcon    *icon,
 {
         g_return_if_fail (GVC_IS_STREAM_STATUS_ICON (icon));
 
-        if (icon->priv->control == control)
+        if (icon->priv->control == control) {
+                if (control != NULL)
+                        update_icon (icon);
                 return;
+        }
 
         if (control != NULL)
                 g_object_ref (control);
@@ -558,7 +1050,6 @@ gvc_stream_status_icon_set_control (GvcStreamStatusIcon    *icon,
                                   G_CALLBACK (on_stream_control_mute_notify),
                                   icon);
 
-                // XXX when no stream set some default icon and "unset" dock
                 update_icon (icon);
         }
 
@@ -567,11 +1058,150 @@ gvc_stream_status_icon_set_control (GvcStreamStatusIcon    *icon,
         g_object_notify_by_pspec (G_OBJECT (icon), properties[PROP_CONTROL]);
 }
 
+void
+gvc_stream_status_icon_set_applet_settings (GvcStreamStatusIcon *icon,
+                                            GSettings           *settings)
+{
+        g_return_if_fail (GVC_IS_STREAM_STATUS_ICON (icon));
+        g_return_if_fail (settings == NULL || G_IS_SETTINGS (settings));
+
+        if (icon->priv->applet_settings == settings)
+                return;
+
+        g_clear_object (&icon->priv->applet_settings);
+
+        if (settings != NULL)
+                icon->priv->applet_settings = g_object_ref (settings);
+
+        update_icon (icon);
+}
+
+void
+gvc_stream_status_icon_set_player_widget (GvcStreamStatusIcon *icon,
+                                          GtkWidget           *player_widget)
+{
+        g_return_if_fail (GVC_IS_STREAM_STATUS_ICON (icon));
+        g_return_if_fail (player_widget == NULL || GTK_IS_WIDGET (player_widget));
+
+        if (icon->priv->player_widget == player_widget)
+                return;
+
+        if (icon->priv->player_widget != NULL) {
+                gtk_container_remove (GTK_CONTAINER (icon->priv->dock_box),
+                                      icon->priv->player_widget);
+                gtk_container_remove (GTK_CONTAINER (icon->priv->dock_box),
+                                      icon->priv->player_separator);
+                icon->priv->player_widget = NULL;
+                icon->priv->player_separator = NULL;
+        }
+
+        if (player_widget != NULL) {
+                GtkWidget *separator;
+
+                icon->priv->player_widget = player_widget;
+                separator = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
+                gtk_widget_set_no_show_all (separator, TRUE);
+                icon->priv->player_separator = separator;
+                gtk_box_pack_start (GTK_BOX (icon->priv->dock_box),
+                                    player_widget,
+                                    FALSE,
+                                    FALSE,
+                                    0);
+                gtk_box_pack_start (GTK_BOX (icon->priv->dock_box),
+                                    separator,
+                                    FALSE,
+                                    FALSE,
+                                    0);
+                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                       player_widget,
+                                       0);
+                gtk_box_reorder_child (GTK_BOX (icon->priv->dock_box),
+                                       separator,
+                                       1);
+        }
+
+        configure_dock_layout (icon, GTK_ORIENTATION_HORIZONTAL, FALSE);
+}
+
 static void
-gvc_stream_status_icon_set_property (GObject       *object,
-                                     guint          prop_id,
-                                     const GValue  *value,
-                                     GParamSpec    *pspec)
+on_mpris_player_tooltip_changed (GvcMprisPlayer      *player,
+                                 GvcStreamStatusIcon *icon)
+{
+        update_icon (icon);
+}
+
+void
+gvc_stream_status_icon_set_mpris_player (GvcStreamStatusIcon *icon,
+                                         GvcMprisPlayer      *player)
+{
+        g_return_if_fail (GVC_IS_STREAM_STATUS_ICON (icon));
+
+        if (icon->priv->player == player)
+                return;
+
+        if (icon->priv->player != NULL)
+                g_signal_handlers_disconnect_by_data (icon->priv->player, icon);
+
+        g_clear_object (&icon->priv->player);
+
+        if (player != NULL) {
+                icon->priv->player = g_object_ref (player);
+                g_signal_connect (player, "metadata-changed", G_CALLBACK (on_mpris_player_tooltip_changed), icon);
+                g_signal_connect (player, "status-changed", G_CALLBACK (on_mpris_player_tooltip_changed), icon);
+        }
+
+        update_icon (icon);
+}
+
+void
+gvc_stream_status_icon_set_player_widget_visible (GvcStreamStatusIcon *icon,
+                                                  gboolean             visible)
+{
+        g_return_if_fail (GVC_IS_STREAM_STATUS_ICON (icon));
+
+        icon->priv->player_widget_visible = visible;
+
+        if (icon->priv->player_separator != NULL)
+                gtk_widget_set_visible (icon->priv->player_separator, visible);
+
+        configure_dock_layout (icon, GTK_ORIENTATION_HORIZONTAL, FALSE);
+}
+
+void
+gvc_stream_status_icon_set_mpris_manager (GvcStreamStatusIcon *icon,
+                                          GvcMprisManager     *manager)
+{
+        g_return_if_fail (GVC_IS_STREAM_STATUS_ICON (icon));
+
+        if (icon->priv->mpris_manager == manager)
+                return;
+
+        g_clear_object (&icon->priv->mpris_manager);
+
+        if (manager != NULL)
+                icon->priv->mpris_manager = g_object_ref (manager);
+}
+
+void
+gvc_stream_status_icon_set_mate_mixer_context (GvcStreamStatusIcon *icon,
+                                               MateMixerContext    *context)
+{
+        g_return_if_fail (GVC_IS_STREAM_STATUS_ICON (icon));
+
+        if (icon->priv->mixer_context == context)
+                return;
+
+        g_clear_object (&icon->priv->mixer_context);
+
+        if (context != NULL)
+                icon->priv->mixer_context = g_object_ref (context);
+}
+
+static void
+gvc_stream_status_icon_set_property (GObject      *object,
+                                     guint         prop_id,
+                                     const GValue *value,
+                                     GParamSpec   *pspec)
 {
         GvcStreamStatusIcon *self = GVC_STREAM_STATUS_ICON (object);
 
@@ -592,10 +1222,10 @@ gvc_stream_status_icon_set_property (GObject       *object,
 }
 
 static void
-gvc_stream_status_icon_get_property (GObject     *object,
-                                     guint        prop_id,
-                                     GValue      *value,
-                                     GParamSpec  *pspec)
+gvc_stream_status_icon_get_property (GObject    *object,
+                                     guint       prop_id,
+                                     GValue     *value,
+                                     GParamSpec *pspec)
 {
         GvcStreamStatusIcon *self = GVC_STREAM_STATUS_ICON (object);
 
@@ -625,7 +1255,14 @@ gvc_stream_status_icon_dispose (GObject *object)
                 icon->priv->dock = NULL;
         }
 
+        if (icon->priv->player != NULL) {
+                g_signal_handlers_disconnect_by_data (icon->priv->player, icon);
+                g_clear_object (&icon->priv->player);
+        }
+
         g_clear_object (&icon->priv->control);
+        g_clear_object (&icon->priv->mpris_manager);
+        g_clear_object (&icon->priv->mixer_context);
 
         G_OBJECT_CLASS (gvc_stream_status_icon_parent_class)->dispose (object);
 }
@@ -668,6 +1305,18 @@ gvc_stream_status_icon_class_init (GvcStreamStatusIconClass *klass)
                                     G_PARAM_STATIC_STRINGS);
 
         g_object_class_install_properties (object_class, N_PROPERTIES, properties);
+
+        signals[PLAYER_SELECTED] =
+                g_signal_new ("player-selected",
+                              G_TYPE_FROM_CLASS (klass),
+                              G_SIGNAL_RUN_LAST,
+                              0,
+                              NULL,
+                              NULL,
+                              NULL,
+                              G_TYPE_NONE,
+                              1,
+                              GVC_TYPE_MPRIS_PLAYER);
 }
 
 static void
@@ -689,8 +1338,11 @@ on_icon_theme_change (GtkSettings         *settings,
 static void
 gvc_stream_status_icon_init (GvcStreamStatusIcon *icon)
 {
-        GtkWidget *frame;
-        GtkWidget *box;
+        GtkWidget       *frame;
+        GtkWidget       *toplevel;
+        GtkStyleContext *context;
+        GdkScreen       *screen;
+        GdkVisual       *visual;
 
         icon->priv = gvc_stream_status_icon_get_instance_private (icon);
 
@@ -717,7 +1369,6 @@ gvc_stream_status_icon_init (GvcStreamStatusIcon *icon)
                           G_CALLBACK (on_status_icon_visible_notify),
                           NULL);
 
-        /* Create the dock window */
         icon->priv->dock = gtk_window_new (GTK_WINDOW_POPUP);
 
         gtk_window_set_decorated (GTK_WINDOW (icon->priv->dock), FALSE);
@@ -748,6 +1399,11 @@ gvc_stream_status_icon_init (GvcStreamStatusIcon *icon)
         gtk_container_add (GTK_CONTAINER (icon->priv->dock), frame);
 
         icon->priv->bar = gvc_channel_bar_new (NULL);
+        icon->priv->volume_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 4);
+        icon->priv->volume_image = GTK_IMAGE (gtk_image_new_from_icon_name ("multimedia-volume-control",
+                                                                            GTK_ICON_SIZE_MENU));
+        gtk_widget_set_halign (GTK_WIDGET (icon->priv->volume_image), GTK_ALIGN_CENTER);
+        gtk_widget_set_valign (GTK_WIDGET (icon->priv->volume_image), GTK_ALIGN_CENTER);
 
         gvc_channel_bar_set_orientation (GVC_CHANNEL_BAR (icon->priv->bar),
                                          GTK_ORIENTATION_VERTICAL);
@@ -763,22 +1419,27 @@ gvc_stream_status_icon_init (GvcStreamStatusIcon *icon)
                          icon->priv->bar,            "extended",
                          G_SETTINGS_BIND_GET);
 
-        /* Set volume control frame, slider and toplevel window to follow panel theme */
-        GtkWidget *toplevel = gtk_widget_get_toplevel (icon->priv->dock);
-        GtkStyleContext *context;
-        context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
-        gtk_style_context_add_class(context,"mate-panel-applet-slider");
-        /* Make transparency possible in gtk3 theme */
-        GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
-        GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
-        gtk_widget_set_visual(GTK_WIDGET(toplevel), visual);
+        toplevel = gtk_widget_get_toplevel (icon->priv->dock);
+        context = gtk_widget_get_style_context (GTK_WIDGET (toplevel));
+        gtk_style_context_add_class (context, "mate-panel-applet-slider");
+        screen = gtk_widget_get_screen (GTK_WIDGET (toplevel));
+        visual = gdk_screen_get_rgba_visual (screen);
+        gtk_widget_set_visual (GTK_WIDGET (toplevel), visual);
 
-        box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
+        icon->priv->dock_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 
-        gtk_container_set_border_width (GTK_CONTAINER (box), 2);
-        gtk_container_add (GTK_CONTAINER (frame), box);
+        gtk_container_set_border_width (GTK_CONTAINER (icon->priv->dock_box), 2);
+        gtk_container_add (GTK_CONTAINER (frame), icon->priv->dock_box);
 
-        gtk_box_pack_start (GTK_BOX (box), icon->priv->bar, TRUE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (icon->priv->volume_box), icon->priv->bar, TRUE, TRUE, 0);
+        gtk_box_pack_start (GTK_BOX (icon->priv->volume_box),
+                            GTK_WIDGET (icon->priv->volume_image),
+                            FALSE,
+                            FALSE,
+                            0);
+        gtk_box_pack_start (GTK_BOX (icon->priv->dock_box), icon->priv->volume_box, TRUE, FALSE, 0);
+
+        configure_dock_layout (icon, GTK_ORIENTATION_HORIZONTAL, FALSE);
 
         g_signal_connect (gtk_settings_get_default (),
                           "notify::gtk-icon-theme-name",
@@ -794,12 +1455,14 @@ gvc_stream_status_icon_finalize (GObject *object)
         icon = GVC_STREAM_STATUS_ICON (object);
 
         g_strfreev (icon->priv->icon_names);
+        g_clear_pointer (&icon->priv->display_name, g_free);
 
         g_signal_handlers_disconnect_by_func (gtk_settings_get_default (),
                                               on_icon_theme_change,
                                               icon);
 
         g_clear_object (&icon->priv->sound_settings);
+        g_clear_object (&icon->priv->applet_settings);
 
         G_OBJECT_CLASS (gvc_stream_status_icon_parent_class)->finalize (object);
 }

--- a/mate-volume-control/gvc-stream-status-icon.h
+++ b/mate-volume-control/gvc-stream-status-icon.h
@@ -25,7 +25,11 @@
 
 #include <glib.h>
 #include <glib-object.h>
+#include <gtk/gtk.h>
 #include <libmatemixer/matemixer.h>
+
+#include "gvc-mpris-manager.h"
+#include "gvc-mpris-player.h"
 
 G_BEGIN_DECLS
 
@@ -51,18 +55,36 @@ struct _GvcStreamStatusIconClass
         GtkStatusIconClass          parent_class;
 };
 
-GType                 gvc_stream_status_icon_get_type         (void) G_GNUC_CONST;
+GType                 gvc_stream_status_icon_get_type                 (void) G_GNUC_CONST;
 
-GvcStreamStatusIcon * gvc_stream_status_icon_new              (MateMixerStreamControl *control,
-                                                               const gchar           **icon_names);
+GvcStreamStatusIcon * gvc_stream_status_icon_new                      (MateMixerStreamControl *control,
+                                                                       const gchar           **icon_names);
 
-void                  gvc_stream_status_icon_set_icon_names   (GvcStreamStatusIcon    *icon,
-                                                               const gchar           **icon_names);
-void                  gvc_stream_status_icon_set_display_name (GvcStreamStatusIcon    *icon,
-                                                                  const gchar         *display_name);
+void                  gvc_stream_status_icon_set_icon_names           (GvcStreamStatusIcon    *icon,
+                                                                       const gchar           **icon_names);
+void                  gvc_stream_status_icon_set_display_name         (GvcStreamStatusIcon    *icon,
+                                                                       const gchar            *display_name);
 
-void                  gvc_stream_status_icon_set_control      (GvcStreamStatusIcon    *icon,
-                                                               MateMixerStreamControl *control);
+void                  gvc_stream_status_icon_set_control              (GvcStreamStatusIcon    *icon,
+                                                                       MateMixerStreamControl *control);
+
+void                  gvc_stream_status_icon_set_applet_settings      (GvcStreamStatusIcon    *icon,
+                                                                       GSettings              *settings);
+
+void                  gvc_stream_status_icon_set_player_widget        (GvcStreamStatusIcon    *icon,
+                                                                       GtkWidget              *player_widget);
+
+void                  gvc_stream_status_icon_set_mpris_player         (GvcStreamStatusIcon    *icon,
+                                                                       GvcMprisPlayer         *player);
+
+void                  gvc_stream_status_icon_set_player_widget_visible (GvcStreamStatusIcon   *icon,
+                                                                        gboolean               visible);
+
+void                  gvc_stream_status_icon_set_mpris_manager        (GvcStreamStatusIcon    *icon,
+                                                                       GvcMprisManager        *manager);
+
+void                  gvc_stream_status_icon_set_mate_mixer_context   (GvcStreamStatusIcon    *icon,
+                                                                       MateMixerContext       *context);
 
 G_END_DECLS
 

--- a/mate-volume-control/meson.build
+++ b/mate-volume-control/meson.build
@@ -27,13 +27,15 @@ libmvc_static = static_library(
 
 if enable_applet
   desktop_data = configuration_data()
+  applet_metadata_output = 'org.mate.applets.GvcApplet.mate-panel-applet.desktop'
   
   if enable_process
     desktop_data.set('APPLET_LOCATION', join_paths(mm_libdir, 'libmate-volume-control-applet.so'))
     desktop_data.set('IN_PROCESS', 'true')
+    applet_metadata_output = 'org.mate.applets.GvcApplet.mate-panel-applet'
     
     libmvca_shared = library(
-      'libmate-volume-control-applet',
+      'mate-volume-control-applet',
       sources: [
         'gvc-stream-applet-icon.c',
         'gvc-applet.c',
@@ -95,7 +97,7 @@ if enable_applet
   )
   i18n.merge_file(
     input : desktop_in_file,
-    output : 'org.mate.applets.GvcApplet.mate-panel-applet.desktop',
+    output : applet_metadata_output,
     type : 'desktop',
     po_dir : po_dir,
     install : true,

--- a/mate-volume-control/meson.build
+++ b/mate-volume-control/meson.build
@@ -9,6 +9,8 @@ cflags = [
 ]
 deps = [
   glib,
+  gio,
+  gio_unix,
   gtk,
   matemixer
 ]
@@ -34,13 +36,16 @@ if enable_applet
     desktop_data.set('IN_PROCESS', 'true')
     applet_metadata_output = 'org.mate.applets.GvcApplet.mate-panel-applet'
     
-    libmvca_shared = library(
-      'mate-volume-control-applet',
-      sources: [
-        'gvc-stream-applet-icon.c',
-        'gvc-applet.c',
-        'applet-main.c'
-      ],
+	    libmvca_shared = library(
+	      'mate-volume-control-applet',
+	      sources: [
+	        'gvc-stream-applet-icon.c',
+	        'gvc-mpris-manager.c',
+	        'gvc-mpris-player.c',
+	        'gvc-player-widget.c',
+	        'gvc-applet.c',
+	        'applet-main.c'
+	      ],
       include_directories: config_inc,
       dependencies: [
         deps,
@@ -68,13 +73,16 @@ if enable_applet
       install : true,
       install_dir : join_paths(mm_datadir, 'dbus-1/services')
     )
-    executable(
-      'mate-volume-control-applet',
-      sources : [
-        'gvc-stream-applet-icon.c',
-        'gvc-applet.c',
-        'applet-main.c'
-      ],
+	    executable(
+	      'mate-volume-control-applet',
+	      sources : [
+	        'gvc-stream-applet-icon.c',
+	        'gvc-mpris-manager.c',
+	        'gvc-mpris-player.c',
+	        'gvc-player-widget.c',
+	        'gvc-applet.c',
+	        'applet-main.c'
+	      ],
       include_directories: config_inc,
       dependencies : [
         deps,
@@ -112,6 +120,9 @@ if enable_statusicon
     sources : [
       'gvc-stream-status-icon.c',
       'gvc-status-icon.c',
+      'gvc-mpris-manager.c',
+      'gvc-mpris-player.c',
+      'gvc-player-widget.c',
       'status-icon-main.c'
     ],
     include_directories: config_inc,
@@ -153,4 +164,3 @@ executable(
   install : true,
   install_dir : get_option('bindir')
 )
-

--- a/meson.build
+++ b/meson.build
@@ -108,6 +108,8 @@ endif
 
 gtk = dependency('gtk+-3.0', version : '>= 3.22.0')
 glib = dependency('glib-2.0', version : '>= 2.50.0')
+gio = dependency('gio-2.0', version : '>= 2.50.0')
+gio_unix = dependency('gio-unix-2.0', version : '>= 2.50.0')
 gdk = dependency('gdk-3.0', version : '>= 3.22.0')
 matemixer = dependency('libmatemixer', version : '>= 1.10.0')
 canberra = dependency('libcanberra-gtk3', version : '>= 0.13')


### PR DESCRIPTION
## Summary

This PR adds MPRIS media-player integration to both the MATE volume applet and the standalone status icon.

The main goal is to expose MPRIS playback controls from the existing volume UI, without requiring a separate media-control applet.

This includes:

- MPRIS player discovery and tracking over D-Bus
- a shared backend for player metadata, playback state, and transport controls
- a reusable player widget for cover art, track information, seeking, and playback actions
- applet integration
- status icon integration following the applet behavior as closely as possible
- new settings/schema entries for media-related behavior
- Meson/build updates, including an in-process/Wayland-related applet fix

## Motivation

The volume applet and status icon already serve as persistent audio-control surfaces, so MPRIS playback control fits the same interaction model.

With this change, users can:

- view the active media player directly from the volume UI
- see track information and player identity
- control playback without opening the player window
- switch between available players
- seek within tracks
- use mouse and touchpad shortcuts directly on the icon
- access player-related actions from the right-click menu

The feature is additive: the existing volume workflow remains the same when no MPRIS-compatible player is running. And you can disable the whole show media player feature can be disabled. 

## Implementation overview

The work is split into several layers.

### 1. Build and settings plumbing

This PR adds:

- Meson wiring for the new MPRIS-related sources
- `gio` / `gio-unix` dependencies required by the player integration
- a new `org.mate.volume-control` schema for media/player-related settings
- an in-process applet metadata/build fix needed while testing the applet path, especially in Wayland sessions

### 2. MPRIS backend

Two internal components were added:

- `GvcMprisManager`
  - discovers and tracks MPRIS players on the session bus
  - listens for player appearance/removal
  - exposes available players
  - selects a best active player

- `GvcMprisPlayer`
  - represents one MPRIS player
  - tracks metadata, playback status, capabilities, and transport state
  - exposes play/pause, next, previous, stop, raise, quit, and seek actions

This keeps D-Bus/MPRIS logic separate from the UI layer.

### 3. Shared player widget

A reusable `GvcPlayerWidget` was added for the popup UI.

It provides:

- player selection when multiple players are available
- title/artist display
- cover art
- playback controls
- repeat/shuffle controls
- seek bar and time display

The widget is shared between the applet and status icon to avoid duplicating the player UI implementation.

### 4. Applet integration

The applet implementation came first and acts as the reference path for the feature.

The applet now:

- tracks active MPRIS players
- embeds the shared player widget in the popup
- can show track text in the panel
- can include player information in tooltips
- supports player-aware middle-click behavior
- supports extra mouse buttons for previous/next track
- supports horizontal touchpad/scroll gestures on the icon for previous/next track
- adds player-related actions and selection in the right-click menu

### 5. Status icon integration

After the applet path was working, I ported the same behavior to the standalone status icon as closely as practical.

The status icon now:

- uses the same MPRIS backend
- reuses the same shared player widget
- exposes player metadata and controls in its popup
- follows the same settings-driven behavior where practical

The intent is to keep the applet and status icon behavior aligned instead of maintaining two unrelated implementations.

## Interaction improvements

In addition to popup controls, this PR adds direct interaction paths:

- configurable middle-click behavior for media control
- extra mouse buttons for previous/next track
- horizontal touchpad/scroll gestures on the icon for previous/next track
- player actions exposed through the right-click menu

This keeps common playback actions available without opening the full player UI.

## Player compatibility

This PR includes compatibility handling inspired by Cinnamon's MPRIS behavior to improve real-world player matching and launch behavior, including Spotify-style desktop integration cases.

## Related input-stream fix

While testing this area, I also adjusted input-stream visibility so recording activity is detected more reliably across input streams, not only the default input stream.

This is separate from MPRIS but included because it affects the same status/applet UI surface.

## Settings added

This PR adds settings for:

- showing track text in the panel
- showing player controls
- middle-click behavior
- horizontal scroll media control behavior
- known player tracking
- tooltip volume visibility
- tooltip player visibility

These settings make the feature configurable rather than forcing one media-control workflow for all users.

## Testing

I tested this manually in a Wayland session.

Verified:

- the applet works in a Wayland session
- in my testing, the applet behaves the same there as it does in an X session
- popup behavior works
- MPRIS player detection works
- media controls work
- player metadata is shown
- the status icon path works after porting the applet behavior across
- existing volume-control behavior remains available

## Review notes

The implementation order was:

1. build/settings groundwork
2. shared MPRIS backend
3. shared player widget
4. applet integration
5. status icon integration

The status icon work is intentionally derived from the applet path rather than being a separate design.

## Why this fits in mate-media

This feature extends the existing audio-control UI instead of adding a separate media-control surface.

It uses the standard MPRIS D-Bus interface, keeps the player logic modular, shares UI between the applet and status icon, preserves the existing volume-control behavior, and was tested in Wayland with the applet behaving the same as it does in an X session.